### PR TITLE
Feature/#12 マイ香水一覧・登録

### DIFF
--- a/app/controllers/fragrances_controller.rb
+++ b/app/controllers/fragrances_controller.rb
@@ -1,0 +1,26 @@
+class FragrancesController < ApplicationController
+  before_action :authenticate_user!
+  def index
+    @fragrances = current_user.fragrances
+  end
+
+  def new
+    @fragrance = Fragrance.new
+  end
+
+  def create
+    @fragrance = current_user.fragrances.build(fragrance_params)
+    if @fragrance.save
+      redirect_to fragrances_path, notice: t('defaults.flash_message.created', item: Board.model_name.human)
+    else
+      flash.now[:alert] = t('defaults.flash_message.not_created', item: Board.model_name.human)
+      render :new, status: :unprocessable_entity
+    end
+  end
+
+  private
+
+  def fragrance_params
+    params.require(:fragrance).permit(:name, :brand)
+  end
+end

--- a/app/controllers/fragrances_controller.rb
+++ b/app/controllers/fragrances_controller.rb
@@ -11,9 +11,9 @@ class FragrancesController < ApplicationController
   def create
     @fragrance = current_user.fragrances.build(fragrance_params)
     if @fragrance.save
-      redirect_to fragrances_path, notice: t('defaults.flash_message.created', item: Fragrance.model_name.human)
+      redirect_to fragrances_path, notice: t("defaults.flash_message.created", item: Fragrance.model_name.human)
     else
-      flash.now[:alert] = t('defaults.flash_message.not_created', item: Fragrance.model_name.human)
+      flash.now[:alert] = t("defaults.flash_message.not_created", item: Fragrance.model_name.human)
       render :new, status: :unprocessable_entity
     end
   end

--- a/app/controllers/fragrances_controller.rb
+++ b/app/controllers/fragrances_controller.rb
@@ -11,9 +11,9 @@ class FragrancesController < ApplicationController
   def create
     @fragrance = current_user.fragrances.build(fragrance_params)
     if @fragrance.save
-      redirect_to fragrances_path, notice: t('defaults.flash_message.created', item: Board.model_name.human)
+      redirect_to fragrances_path, notice: t('defaults.flash_message.created', item: Fragrance.model_name.human)
     else
-      flash.now[:alert] = t('defaults.flash_message.not_created', item: Board.model_name.human)
+      flash.now[:alert] = t('defaults.flash_message.not_created', item: Fragrance.model_name.human)
       render :new, status: :unprocessable_entity
     end
   end

--- a/app/helpers/fragrances_helper.rb
+++ b/app/helpers/fragrances_helper.rb
@@ -1,0 +1,2 @@
+module FragrancesHelper
+end

--- a/app/models/fragrance.rb
+++ b/app/models/fragrance.rb
@@ -1,0 +1,6 @@
+class Fragrance < ApplicationRecord
+  validates :name, presence: true
+  validates :brand, presence: true
+
+  belongs_to :user
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -3,4 +3,6 @@ class User < ApplicationRecord
   # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :validatable
+
+  has_many :fragrances, dependent: :destroy
 end

--- a/app/views/fragrances/index.html.erb
+++ b/app/views/fragrances/index.html.erb
@@ -1,0 +1,15 @@
+<h1><%= t('.title') %></h1>
+
+<% if @fragrances.any? %>
+  <ul class="space-y-4">
+    <% @fragrances.each do |fragrance| %>
+      <li class="p-4 border rounded shadow-sm bg-white">
+        <strong><%= fragrance.brand %></strong> - <%= fragrance.name %>
+      </li>
+    <% end %>
+  </ul>
+<% else %>
+  <p>まだ香水が登録されていません。</p>
+<% end %>
+
+<%= link_to "香水を登録する", new_fragrance_path, class: "btn btn-primary" %>

--- a/app/views/fragrances/new.html.erb
+++ b/app/views/fragrances/new.html.erb
@@ -1,0 +1,27 @@
+<h1><%= t('.title') %></h1>
+
+<%= form_with model: @fragrance, local: true do |form| %>
+  <% if @fragrance.errors.any? %>
+    <div class="bg-red-100 border border-red-400 text-red-700 px-4 py-2 rounded mb-4">
+      <ul>
+        <% @fragrance.errors.full_messages.each do |message| %>
+          <li>・<%= message %></li>
+        <% end %>
+      </ul>
+    </div>
+  <% end %>
+
+  <div class="mb-4">
+    <%= form.label :brand, class: "block font-bold mb-1" %>
+    <%= form.text_field :brand, class: "border rounded w-full py-2 px-3" %>
+  </div>
+
+  <div class="mb-4">
+    <%= form.label :name, class: "block font-bold mb-1" %>
+    <%= form.text_field :name, class: "border rounded w-full py-2 px-3" %>
+  </div>
+
+  <%= form.submit "登録する", class: "btn btn-primary" %>
+<% end %>
+
+<%= link_to "一覧に戻る", fragrances_path, class: "text-blue-500 underline mt-4 inline-block" %>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -4,6 +4,9 @@
     </div>
     <div class="flex-none space-x-2">
       <% if user_signed_in? %>
+        <span class="text-sm font-semibold">
+          <%= current_user.name %>さん
+        </span>
         <%= link_to "ログアウト", destroy_user_session_path, method: :delete, data: { turbo: false }, class: "btn btn-outline" %>
       <% else %>
         <%= link_to "新規登録", new_user_registration_path, class: "btn btn-primary" %>

--- a/app/views/shared/_menu.html.erb
+++ b/app/views/shared/_menu.html.erb
@@ -1,6 +1,6 @@
 <ul class="menu md:flex flex-col w-48 p-4 bg-base-200 text-base-content">
   <li>
-    <%= link_to '#', class:"mb-2 p-4 rounded" do %>
+    <%= link_to fragrances_path, class:"mb-2 p-4 rounded" do %>
       <i class="fa-solid fa-spray-can-sparkles"></i>
       <span>マイ香水</span>
     <% end %>

--- a/config/locales/activerecord/ja.yml
+++ b/config/locales/activerecord/ja.yml
@@ -2,9 +2,13 @@ ja:
   activerecord:
     models:
       user: ユーザー
+      fragrance: マイ香水
     attributes:
       user:
         name: アカウント名
         email: メールアドレス
         password: パスワード
         password_confirmation: パスワード確認
+      fragrance:
+        name: 香水名
+        brand: ブランド名

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -20,3 +20,8 @@ ja:
   header:
     login: ログイン
     logout: ログアウト
+  fragrances:
+    index:
+      title: マイ香水一覧
+    new:
+      title: マイ香水を登録

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,7 +4,7 @@ Rails.application.routes.draw do
     sessions: "users/sessions"
   }
   root "static_pages#top"
-  resources :fragrances, only: %i[index, new, create]
+  resources :fragrances
   # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html
 
   # Reveal health status on /up that returns 200 if the app boots with no exceptions, otherwise 500.

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,6 +4,7 @@ Rails.application.routes.draw do
     sessions: "users/sessions"
   }
   root "static_pages#top"
+  resources :fragrances, only: %i[index, new, create]
   # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html
 
   # Reveal health status on /up that returns 200 if the app boots with no exceptions, otherwise 500.

--- a/db/migrate/20250610011635_create_fragrances.rb
+++ b/db/migrate/20250610011635_create_fragrances.rb
@@ -1,0 +1,11 @@
+class CreateFragrances < ActiveRecord::Migration[7.2]
+  def change
+    create_table :fragrances do |t|
+      t.string :name, null: false
+      t.string :brand, null: false
+      t.references :user, null: false, foreign_key: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,9 +10,18 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_06_02_023309) do
+ActiveRecord::Schema[7.2].define(version: 2025_06_10_011635) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "fragrances", force: :cascade do |t|
+    t.string "name", null: false
+    t.string "brand", null: false
+    t.bigint "user_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["user_id"], name: "index_fragrances_on_user_id"
+  end
 
   create_table "users", force: :cascade do |t|
     t.string "email", default: "", null: false
@@ -26,4 +35,6 @@ ActiveRecord::Schema[7.2].define(version: 2025_06_02_023309) do
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end
+
+  add_foreign_key "fragrances", "users"
 end

--- a/test/controllers/fragrances_controller_test.rb
+++ b/test/controllers/fragrances_controller_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class FragrancesControllerTest < ActionDispatch::IntegrationTest
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/test/fixtures/fragrances.yml
+++ b/test/fixtures/fragrances.yml
@@ -1,0 +1,11 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  name: MyString
+  brand: MyString
+  user: one
+
+two:
+  name: MyString
+  brand: MyString
+  user: two

--- a/test/models/fragrance_test.rb
+++ b/test/models/fragrance_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class FragranceTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
# 概要
Fragranceモデルを作成し、マイ香水の登録と一覧表示を実装

# 実施した内容
- Fragranceモデル作成し、userとのアソシエーション設定
- ルーティング・コントローラー・ビューの作成
- 左メニューからマイ香水一覧へのリンク
- 未ログイン状態では閲覧不可

# 補足

# 関連issue
#12 #13 