### PR TITLE
feature/#16 マイ香水削除機能

### DIFF
--- a/app/controllers/fragrances_controller.rb
+++ b/app/controllers/fragrances_controller.rb
@@ -36,6 +36,8 @@ class FragrancesController < ApplicationController
   end
 
   def destroy
+    @fragrance.destroy
+    redirect_to fragrances_path, notice: t("defaults.flash_message.deleted", item: Fragrance.model_name.human)
   end
 
   private

--- a/app/views/fragrances/show.html.erb
+++ b/app/views/fragrances/show.html.erb
@@ -5,6 +5,6 @@
 
 <div class="mt-4 space-x-2">
   <%= link_to t('defaults.edit'), edit_fragrance_path(@fragrance), class: "btn btn-outline" %>
-  <%= link_to t('defaults.delete'), '#', method: :delete, data: { confirm: t('defaults.delete_confirm') }, class: "btn btn-error" %>
+  <%= link_to t('defaults.delete'), fragrance_path(@fragrance), method: :delete, data: { confirm: t('defaults.delete_confirm') }, class: "btn btn-error" %>
   <%= link_to t('defaults.back_index'), fragrances_path, class: "btn" %>
 </div>


### PR DESCRIPTION
# 概要
詳細画面からマイ香水を削除できるように

# 実施した内容
- fragranceコントローラーにdestroyアクション追加
- マイ香水詳細画面に削除ボタンを設置

# 補足
削除確認のモーダルはデフォルトなのであとで変えたい

# 関連issue
#16 
