### PR TITLE
Feature/#50 ページタイトルの動的出力

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,2 +1,10 @@
 module ApplicationHelper
+  def full_title(page_title = "")
+    base_title = "FragranceLog"
+    if page_title.present?
+      "#{page_title}｜#{base_title}"
+    else
+      base_title
+    end
+  end
 end

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -1,4 +1,5 @@
-<h2>新規登録</h2>
+<% content_for(:title, t("devise.registrations.new.sign_up")) %>
+<h2><%= t("devise.registrations.new.sign_up") %></h2>
 
 <%= form_for(resource, as: resource_name, url: registration_path(resource_name)) do |f| %>
   <%= render "devise/shared/error_messages", resource: resource %>

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -1,4 +1,5 @@
-<h2>ログイン</h2>
+<% content_for(:title, t("devise.sessions.new.sign_in")) %>
+<h2><%= t("devise.sessions.new.sign_in") %></h2>
 
 <%= form_for(resource, as: resource_name, url: session_path(resource_name)) do |f| %>
   <div class="field">

--- a/app/views/fragrances/edit.html.erb
+++ b/app/views/fragrances/edit.html.erb
@@ -1,3 +1,4 @@
+<% content_for(:title, t('.title')) %>
 <h2><%= t('.title') %></h2>
 
 <%= render "form", fragrance: @fragrance %>

--- a/app/views/fragrances/index.html.erb
+++ b/app/views/fragrances/index.html.erb
@@ -1,3 +1,4 @@
+<% content_for(:title, t('.title')) %>
 <h1><%= t('.title') %></h1>
 
 <% if @fragrances.any? %>

--- a/app/views/fragrances/new.html.erb
+++ b/app/views/fragrances/new.html.erb
@@ -1,3 +1,4 @@
+<% content_for(:title, t('.title')) %>
 <h1><%= t('.title') %></h1>
 
 <%= render "form", fragrance: @fragrance %>

--- a/app/views/fragrances/show.html.erb
+++ b/app/views/fragrances/show.html.erb
@@ -1,3 +1,4 @@
+<% content_for(:title, @fragrance.name) %>
 <h1><%= t('.title') %></h1>
 
 <p><%= t('activerecord.attributes.fragrance.brand') %>: <%= @fragrance.brand %></p>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html data-theme="lemonade">
   <head>
-    <title><%= content_for(:title) || "FragranceLog" %></title>
+    <title><%= full_title(yield(:title)) %></title>
     <meta name="viewport" content="width=device-width,initial-scale=1">
     <meta name="apple-mobile-web-app-capable" content="yes">
     <%= csrf_meta_tags %>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -7,10 +7,10 @@
         <span class="text-sm font-semibold">
           <%= current_user.name %>さん
         </span>
-        <%= link_to "ログアウト", destroy_user_session_path, method: :delete, data: { turbo: false }, class: "btn btn-outline" %>
+        <%= link_to t('header.logout'), destroy_user_session_path, method: :delete, data: { turbo: false }, class: "btn btn-outline" %>
       <% else %>
-        <%= link_to "新規登録", new_user_registration_path, class: "btn btn-primary" %>
-        <%= link_to "ログイン", new_user_session_path, class: "btn btn-primary" %>
+        <%= link_to t('header.sign_up'), new_user_registration_path, class: "btn btn-primary" %>
+        <%= link_to t('header.login'), new_user_session_path, class: "btn btn-primary" %>
       <% end %>
     </div>
   </header>

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -24,11 +24,12 @@ ja:
   header:
     login: ログイン
     logout: ログアウト
+    sign_up: アカウント登録
   fragrances:
     index:
       title: マイ香水一覧
     new:
-      title: マイ香水を登録
+      title: マイ香水登録
     show:
       title: マイ香水詳細
     edit:


### PR DESCRIPTION
# 概要
「各ページタイトル｜FragranceLog」という形で表示されるように

# 実施した内容
- helperにタイトル表示用のメソッド定義
- application.html.erbのtitleでメソッドを使用
- 各ページでcontent_forを使ってタイトル用意

# 補足
ヘッダーのi18nがまだだった部分も直した

# 関連issue
