### PR TITLE
Feature/#19 カレンダー記録の投稿機能

### DIFF
--- a/app/models/calendar.rb
+++ b/app/models/calendar.rb
@@ -5,4 +5,20 @@ class Calendar < ApplicationRecord
   validates :fragrance_id, presence: true
   validates :start_time, presence: true
   validates :user_id, uniqueness: { scope: :start_time, message: "この日はすでに記録があります" }
+
+  enum weather: {
+    sunny: 0,
+    cloudy: 1,
+    rainy: 2,
+    snowy: 3,
+  }, _prefix: :weather
+
+  enum mood: {
+    happy: 0,
+    relaxed: 1,
+    neutral: 2,
+    sad: 3,
+    angry: 4,
+    tired: 5,
+  }, _prefix: :mood
 end

--- a/app/models/calendar.rb
+++ b/app/models/calendar.rb
@@ -2,6 +2,7 @@ class Calendar < ApplicationRecord
   belongs_to :user
   belongs_to :fragrance
 
+  validates :memo, length: { maximum: 1000 }
   validates :start_time, presence: true
   validates :user_id, uniqueness: { scope: :start_time, message: "この日はすでに記録があります" }
 
@@ -9,7 +10,7 @@ class Calendar < ApplicationRecord
     sunny: 0,
     cloudy: 1,
     rainy: 2,
-    snowy: 3,
+    snowy: 3
   }, _prefix: :weather
 
   enum mood: {
@@ -18,6 +19,6 @@ class Calendar < ApplicationRecord
     neutral: 2,
     sad: 3,
     angry: 4,
-    tired: 5,
+    tired: 5
   }, _prefix: :mood
 end

--- a/app/models/calendar.rb
+++ b/app/models/calendar.rb
@@ -2,7 +2,6 @@ class Calendar < ApplicationRecord
   belongs_to :user
   belongs_to :fragrance
 
-  validates :fragrance_id, presence: true
   validates :start_time, presence: true
   validates :user_id, uniqueness: { scope: :start_time, message: "この日はすでに記録があります" }
 

--- a/app/views/calendars/index.html.erb
+++ b/app/views/calendars/index.html.erb
@@ -4,8 +4,16 @@
   <%= date.day %>
 
   <% calendars.each do |calendar| %>
-    <div>
-      <%= calendar.fragrance.name %>
+    <div class="mt-1">
+      <div><%= calendar.fragrance.name %></div>
+
+      <% if calendar.fragrance.image.attached? %>
+        <%= image_tag calendar.fragrance.image, class: "mt-1 rounded" %>
+      <% else %>
+        <%= image_tag "default_fragrance.png", class: "mt-1 rounded w-24 h-24 object-contain" %>
+      <% end %>
     </div>
   <% end %>
 <% end %>
+
+<%= link_to "新しく記録する", new_calendar_path, class: "btn btn-primary" %>

--- a/app/views/calendars/index.html.erb
+++ b/app/views/calendars/index.html.erb
@@ -1,4 +1,6 @@
-<h2 class="text-xl font-bold mb-4">記録カレンダー</h2>
+<% content_for(:title, t('.title')) %>
+<h1><%= t('.title') %></h1>
+
 
 <%= month_calendar events: @calendars do |date, calendars| %>
   <%= date.day %>
@@ -8,7 +10,7 @@
       <div><%= calendar.fragrance.name %></div>
 
       <% if calendar.fragrance.image.attached? %>
-        <%= image_tag calendar.fragrance.image, class: "mt-1 rounded" %>
+        <%= image_tag calendar.fragrance.image, class: "w-24 h-24 object-contain rounded" %>
       <% else %>
         <%= image_tag "default_fragrance.png", class: "mt-1 rounded w-24 h-24 object-contain" %>
       <% end %>

--- a/app/views/calendars/new.html.erb
+++ b/app/views/calendars/new.html.erb
@@ -1,4 +1,6 @@
-<h2 class="text-xl font-bold mb-4">香水の使用記録を追加</h2>
+<% content_for(:title, t('.title')) %>
+<h1><%= t('.title') %></h1>
+
 
 <%= form_with model: @calendar, local: true do |f| %>
   <% if @calendar.errors.any? %>
@@ -12,19 +14,19 @@
   <% end %>
   <!-- 日付 -->
   <div class="mb-4">
-    <%= f.label :start_time, "日付", class: "block font-semibold mb-1" %>
+    <%= f.label :start_time, class: "block font-semibold mb-1" %>
     <%= f.date_select :start_time, class: "w-full border rounded p-2" %>
   </div>
 
   <!-- 香水 -->
   <div class="mb-4">
-    <%= f.label :fragrance_id, "使用した香水", class: "block font-semibold mb-1" %>
+    <%= f.label :fragrance_id, class: "block font-semibold mb-1" %>
     <%= f.collection_select :fragrance_id, current_user.fragrances, :id, :name, { prompt: "選択してください" }, class: "w-full border rounded p-2" %>
   </div>
 
   <!-- 天気 -->
   <div class="mb-4">
-    <%= f.label :weather, "天気", class: "block font-semibold mb-1" %>
+    <%= f.label :weather, class: "block font-semibold mb-1" %>
     <div class="flex gap-4">
       <% Calendar.weathers.each do |key, _value| %>
         <label class="flex items-center gap-1">
@@ -43,7 +45,7 @@
 
   <!-- 気分 -->
   <div class="mb-4">
-    <%= f.label :mood, "気分", class: "block font-semibold mb-1" %>
+    <%= f.label :mood, class: "block font-semibold mb-1" %>
     <div class="flex flex-wrap gap-4">
       <% Calendar.moods.each do |key, _value| %>
         <label class="flex items-center gap-1">
@@ -63,12 +65,12 @@
 
   <!-- メモ -->
   <div class="mb-4">
-    <%= f.label :memo, "メモ", class: "block font-semibold mb-1" %>
+    <%= f.label :memo, class: "block font-semibold mb-1" %>
     <%= f.text_area :memo, rows: 3, class: "w-full border rounded p-2" %>
   </div>
 
   <!-- ボタン -->
   <div class="flex justify-end">
-    <%= f.submit "記録する", class: "btn btn-primary" %>
+    <%= f.submit class: "btn btn-primary" %>
   </div>
 <% end %>

--- a/app/views/calendars/new.html.erb
+++ b/app/views/calendars/new.html.erb
@@ -66,7 +66,8 @@
   <!-- メモ -->
   <div class="mb-4">
     <%= f.label :memo, class: "block font-semibold mb-1" %>
-    <%= f.text_area :memo, rows: 3, class: "w-full border rounded p-2" %>
+    <%= f.text_area :memo, maxlength: 1000, rows: 3, class: "w-full border rounded p-2" %>
+    <p class="text-sm text-gray-500">※1000文字以内</p>
   </div>
 
   <!-- ボタン -->

--- a/app/views/calendars/new.html.erb
+++ b/app/views/calendars/new.html.erb
@@ -1,0 +1,74 @@
+<h2 class="text-xl font-bold mb-4">香水の使用記録を追加</h2>
+
+<%= form_with model: @calendar, local: true do |f| %>
+  <% if @calendar.errors.any? %>
+    <div class="bg-red-100 border border-red-400 text-red-700 px-4 py-2 rounded mb-4">
+      <ul>
+        <% @calendar.errors.full_messages.each do |message| %>
+          <li>・<%= message %></li>
+        <% end %>
+      </ul>
+    </div>
+  <% end %>
+  <!-- 日付 -->
+  <div class="mb-4">
+    <%= f.label :start_time, "日付", class: "block font-semibold mb-1" %>
+    <%= f.date_select :start_time, class: "w-full border rounded p-2" %>
+  </div>
+
+  <!-- 香水 -->
+  <div class="mb-4">
+    <%= f.label :fragrance_id, "使用した香水", class: "block font-semibold mb-1" %>
+    <%= f.collection_select :fragrance_id, current_user.fragrances, :id, :name, { prompt: "選択してください" }, class: "w-full border rounded p-2" %>
+  </div>
+
+  <!-- 天気 -->
+  <div class="mb-4">
+    <%= f.label :weather, "天気", class: "block font-semibold mb-1" %>
+    <div class="flex gap-4">
+      <% Calendar.weathers.each do |key, _value| %>
+        <label class="flex items-center gap-1">
+          <%= f.radio_button :weather, key %>
+          <%# 絵文字でラベル表示 %>
+          <%= {
+            sunny: "☀️",
+            cloudy: "☁️",
+            rainy: "☔️",
+            snowy: "❄️"
+          }[key.to_sym] %>
+        </label>
+      <% end %>
+    </div>
+  </div>
+
+  <!-- 気分 -->
+  <div class="mb-4">
+    <%= f.label :mood, "気分", class: "block font-semibold mb-1" %>
+    <div class="flex flex-wrap gap-4">
+      <% Calendar.moods.each do |key, _value| %>
+        <label class="flex items-center gap-1">
+          <%= f.radio_button :mood, key %>
+          <%= {
+            happy: "😊",
+            relaxed: "😌",
+            neutral: "😐",
+            sad: "😢",
+            angry: "😠",
+            tired: "😴"
+          }[key.to_sym] %>
+        </label>
+      <% end %>
+    </div>
+  </div>
+
+  <!-- メモ -->
+  <div class="mb-4">
+    <%= f.label :memo, "メモ", class: "block font-semibold mb-1" %>
+    <%= f.text_area :memo, rows: 3, class: "w-full border rounded p-2" %>
+  </div>
+
+  <!-- ボタン -->
+  <div class="flex justify-end">
+    <%= f.submit "記録する", class: "btn btn-primary" %>
+  </div>
+<% end %>

--- a/app/views/simple_calendar/_month_calendar.html.erb
+++ b/app/views/simple_calendar/_month_calendar.html.erb
@@ -1,6 +1,6 @@
 <div class="simple-calendar">
   <div class="calendar-heading">
-    <time datetime="<%= start_date.strftime('%Y-%m') %>" class="calendar-title"><%= t('date.month_names')[start_date.month] %> <%= start_date.year %></time>
+    <time datetime="<%= start_date.strftime('%Y-%m') %>" class="calendar-title"><%= start_date.year %> <%= t('date.month_names')[start_date.month] %> </time>
 
     <nav>
       <%= link_to t('simple_calendar.previous', default: 'Previous'), calendar.url_for_previous_view %>

--- a/config/locales/activerecord/ja.yml
+++ b/config/locales/activerecord/ja.yml
@@ -3,6 +3,7 @@ ja:
     models:
       user: ユーザー
       fragrance: マイ香水
+      calendar: カレンダー
     attributes:
       user:
         name: アカウント名
@@ -13,3 +14,11 @@ ja:
         name: 香水名
         brand: ブランド名
         image: ボトル画像
+      calendar:
+        start_time: 日付
+        fragrance_id: 使用した香水
+        fragrance: 使用した香水
+        user_id: ""
+        weather: 天気
+        mood: 気分
+        memo: メモ

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -34,3 +34,11 @@ ja:
       title: マイ香水詳細
     edit:
       title: マイ香水編集
+  calendars:
+    index:
+      title: 記録カレンダー
+    new:
+      title: 新しく記録する
+  simple_calendar:
+    previous: "<<"
+    next: ">>"

--- a/db/migrate/20250613071946_change_weather_and_mood_type_in_calendars.rb
+++ b/db/migrate/20250613071946_change_weather_and_mood_type_in_calendars.rb
@@ -1,0 +1,6 @@
+class ChangeWeatherAndMoodTypeInCalendars < ActiveRecord::Migration[7.2]
+  def change
+    change_column :calendars, :weather, 'integer USING weather::integer'
+    change_column :calendars, :mood, 'integer USING mood::integer'
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_06_13_050045) do
+ActiveRecord::Schema[7.2].define(version: 2025_06_13_071946) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -44,8 +44,8 @@ ActiveRecord::Schema[7.2].define(version: 2025_06_13_050045) do
 
   create_table "calendars", force: :cascade do |t|
     t.datetime "start_time", null: false
-    t.string "weather"
-    t.string "mood"
+    t.integer "weather"
+    t.integer "mood"
     t.text "memo"
     t.bigint "user_id", null: false
     t.bigint "fragrance_id", null: false


### PR DESCRIPTION
# 概要
日付と使用香水を選択してカレンダーに記録できる機能

# 実施した内容
- weather,moodカラムをinteger型に変更
- enumでweather4種、mood6種を定義
- コントローラーにnew,createアクション記述
- 入力フォームのビュー作成(日付、使用香水、天気、気分、メモが書ける)
- カレンダー画面に新規登録ボタン設置

# 補足
天気、気分、メモは未入力OK
同じ日付に登録できる香水は１つまで

# 関連issue
#19 
