### PR TITLE
Feature/#20 カレンダー詳細

### DIFF
--- a/app/controllers/calendars_controller.rb
+++ b/app/controllers/calendars_controller.rb
@@ -1,5 +1,6 @@
 class CalendarsController < ApplicationController
   before_action :authenticate_user!
+  before_action :set_calendar, only: [ :show, :edit, :update, :destroy ]
 
   def index
     @calendars = current_user.calendars.includes(:fragrance)
@@ -17,6 +18,18 @@ class CalendarsController < ApplicationController
       flash.now[:alert] = t("defaults.flash_message.not_created", item: Calendar.model_name.human)
       render :new, status: :unprocessable_entity
     end
+  end
+
+  def show
+  end
+
+  def edit
+  end
+
+  def update
+  end
+
+  def destroy
   end
 
   private

--- a/app/helpers/calendars_helper.rb
+++ b/app/helpers/calendars_helper.rb
@@ -1,5 +1,6 @@
 module CalendarsHelper
   def weather_icon_tag(key)
+    return unless key.present?
     style = {
       sunny:    '#FFD43B',
       cloudy:   '#9CA3AF',
@@ -18,6 +19,7 @@ module CalendarsHelper
   end
 
   def mood_icon_tag(key)
+    return unless key.present?
     style = {
       happy:   '#FACC15', # yellow-400
       relaxed: '#6EE7B7', # green-300

--- a/app/helpers/calendars_helper.rb
+++ b/app/helpers/calendars_helper.rb
@@ -2,18 +2,18 @@ module CalendarsHelper
   def weather_icon_tag(key)
     return unless key.present?
     style = {
-      sunny:    '#FFD43B',
-      cloudy:   '#9CA3AF',
-      rainy:    '#3B82F6',
-      snowy:    '#BFDBFE',
-    }[key.to_sym] || '#D1D5DB'
+      sunny:    "#FFD43B",
+      cloudy:   "#9CA3AF",
+      rainy:    "#3B82F6",
+      snowy:    "#BFDBFE"
+    }[key.to_sym] || "#D1D5DB"
 
     icon = {
-      sunny:    'sun',
-      cloudy:   'cloud',
-      rainy:    'umbrella',
-      snowy:    'snowflake',
-    }[key.to_sym] || 'question'
+      sunny:    "sun",
+      cloudy:   "cloud",
+      rainy:    "umbrella",
+      snowy:    "snowflake"
+    }[key.to_sym] || "question"
 
     tag.i class: "fa-solid fa-#{icon}", style: "color: #{style};"
   end
@@ -21,22 +21,22 @@ module CalendarsHelper
   def mood_icon_tag(key)
     return unless key.present?
     style = {
-      happy:   '#FACC15', # yellow-400
-      relaxed: '#6EE7B7', # green-300
-      neutral: '#9CA3AF', # gray-400
-      sad:     '#60A5FA', # blue-400
-      angry:   '#F87171', # red-400
-      tired:   '#A78BFA', # purple-400
-    }[key.to_sym] || '#D1D5DB'
+      happy:   "#FACC15", # yellow-400
+      relaxed: "#6EE7B7", # green-300
+      neutral: "#9CA3AF", # gray-400
+      sad:     "#60A5FA", # blue-400
+      angry:   "#F87171", # red-400
+      tired:   "#A78BFA" # purple-400
+    }[key.to_sym] || "#D1D5DB"
 
     icon = {
-      happy:   'face-laugh',
-      relaxed: 'face-smile',
-      neutral: 'face-meh',
-      sad:     'face-sad-tear',
-      angry:   'face-angry',
-      tired:   'face-tired',
-    }[key.to_sym] || 'question'
+      happy:   "face-laugh",
+      relaxed: "face-smile",
+      neutral: "face-meh",
+      sad:     "face-sad-tear",
+      angry:   "face-angry",
+      tired:   "face-tired"
+    }[key.to_sym] || "question"
 
     tag.i class: "fa-solid fa-#{icon}", style: "color: #{style};"
   end

--- a/app/helpers/calendars_helper.rb
+++ b/app/helpers/calendars_helper.rb
@@ -1,2 +1,41 @@
 module CalendarsHelper
+  def weather_icon_tag(key)
+    style = {
+      sunny:    '#FFD43B',
+      cloudy:   '#9CA3AF',
+      rainy:    '#3B82F6',
+      snowy:    '#BFDBFE',
+    }[key.to_sym] || '#D1D5DB'
+
+    icon = {
+      sunny:    'sun',
+      cloudy:   'cloud',
+      rainy:    'umbrella',
+      snowy:    'snowflake',
+    }[key.to_sym] || 'question'
+
+    tag.i class: "fa-solid fa-#{icon}", style: "color: #{style};"
+  end
+
+  def mood_icon_tag(key)
+    style = {
+      happy:   '#FACC15', # yellow-400
+      relaxed: '#6EE7B7', # green-300
+      neutral: '#9CA3AF', # gray-400
+      sad:     '#60A5FA', # blue-400
+      angry:   '#F87171', # red-400
+      tired:   '#A78BFA', # purple-400
+    }[key.to_sym] || '#D1D5DB'
+
+    icon = {
+      happy:   'face-laugh',
+      relaxed: 'face-smile',
+      neutral: 'face-meh',
+      sad:     'face-sad-tear',
+      angry:   'face-angry',
+      tired:   'face-tired',
+    }[key.to_sym] || 'question'
+
+    tag.i class: "fa-solid fa-#{icon}", style: "color: #{style};"
+  end
 end

--- a/app/views/calendars/index.html.erb
+++ b/app/views/calendars/index.html.erb
@@ -7,12 +7,16 @@
 
   <% calendars.each do |calendar| %>
     <div class="mt-1">
-      <div><%= calendar.fragrance.name %></div>
+      <%= link_to calendar_path(calendar), class: "text-sm text-green-800 font-semibold hover:underline" do %>
+        <%= calendar.fragrance.name %>
+      <% end %>
 
-      <% if calendar.fragrance.image.attached? %>
-        <%= image_tag calendar.fragrance.image, class: "w-24 h-24 object-contain rounded" %>
-      <% else %>
-        <%= image_tag "default_fragrance.png", class: "mt-1 rounded w-24 h-24 object-contain" %>
+      <%= link_to calendar_path(calendar) do %>
+        <% if calendar.fragrance.image.attached? %>
+          <%= image_tag calendar.fragrance.image, class: "w-24 h-24 object-contain rounded" %>
+        <% else %>
+          <%= image_tag "default_fragrance.png", class: "mt-1 rounded w-24 h-24 object-contain" %>
+        <% end %>
       <% end %>
     </div>
   <% end %>

--- a/app/views/calendars/new.html.erb
+++ b/app/views/calendars/new.html.erb
@@ -31,13 +31,7 @@
       <% Calendar.weathers.each do |key, _value| %>
         <label class="flex items-center gap-1">
           <%= f.radio_button :weather, key %>
-          <%# 絵文字でラベル表示 %>
-          <%= {
-            sunny: "☀️",
-            cloudy: "☁️",
-            rainy: "☔️",
-            snowy: "❄️"
-          }[key.to_sym] %>
+          <%= weather_icon_tag(key) %>
         </label>
       <% end %>
     </div>
@@ -50,14 +44,7 @@
       <% Calendar.moods.each do |key, _value| %>
         <label class="flex items-center gap-1">
           <%= f.radio_button :mood, key %>
-          <%= {
-            happy: "😊",
-            relaxed: "😌",
-            neutral: "😐",
-            sad: "😢",
-            angry: "😠",
-            tired: "😴"
-          }[key.to_sym] %>
+          <%= mood_icon_tag(key) %>
         </label>
       <% end %>
     </div>

--- a/app/views/calendars/show.html.erb
+++ b/app/views/calendars/show.html.erb
@@ -1,0 +1,50 @@
+<% content_for(:title, t('.title')) %>
+
+<div class="p-6 bg-ivory min-h-screen">
+  <h2 class="text-xl font-bold text-center text-green-800 mb-6">
+    <%= l(@calendar.start_time, format: :japanese) %><%= t('.record') %>
+  </h2>
+
+  <div class="flex flex-col md:flex-row gap-8 items-start justify-center">
+    <!-- 左側：香水情報 -->
+    <div class="flex flex-col items-center text-center">
+      <p class="text-sm font-semibold"><%= @calendar.fragrance.brand %></p>
+      <p class="text-xl font-bold"><%= @calendar.fragrance.name %></p>
+
+      <% if @calendar.fragrance.image.attached? %>
+        <%= image_tag @calendar.fragrance.image, class: "w-48 h-48 object-cover rounded-xl mb-4" %>
+      <% else %>
+        <%= image_tag "default_fragrance.png", class: "w-48 h-48 object-contain rounded" %>
+      <% end %>
+
+    </div>
+
+    <!-- 右側：天気・気分・メモ -->
+    <div class="flex flex-col gap-4 w-full md:w-1/2">
+      <div class="flex items-center gap-4">
+        <p class="font-semibold w-20"><%= t('activerecord.attributes.calendar.weather') %></p>
+        <%= weather_icon_tag(@calendar.weather) %>
+      </div>
+
+      <div class="flex items-center gap-4">
+        <p class="font-semibold w-20"><%= t('activerecord.attributes.calendar.mood') %></p>
+        <%= mood_icon_tag(@calendar.mood) %>
+      </div>
+
+      <div>
+        <p class="font-semibold mb-1"><%= t('activerecord.attributes.calendar.memo') %></p>
+        <% if @calendar.memo.present? %>
+          <div class="p-2 border rounded-md text-sm text-gray-800 bg-white">
+            <%= simple_format(@calendar.memo) %>
+          </div>
+        <% else %>
+          <p class="text-gray-400 text-sm"><%= t('.blank') %></p>
+        <% end %>
+      </div>
+    </div>
+  </div>
+
+  <div class="text-center mt-8">
+    <%= link_to t('defaults.back_index'), calendars_path, class: "text-sm text-gray-500 underline" %>
+  </div>
+</div>

--- a/app/views/shared/_menu.html.erb
+++ b/app/views/shared/_menu.html.erb
@@ -2,25 +2,25 @@
   <li>
     <%= link_to fragrances_path, class:"mb-2 p-4 rounded" do %>
       <i class="fa-solid fa-spray-can-sparkles"></i>
-      <span>マイ香水</span>
+      <span><%= t('menu.fragrance') %></span>
     <% end %>
   </li>
   <li>
     <%= link_to calendars_path, class:"mb-2 p-4 rounded" do %>
       <i class="fa-solid fa-calendar"></i>
-      <span>カレンダー</span>
+      <span><%= t('menu.calendar') %></span>
     <% end %>
   </li>
   <li>
     <%= link_to '#', class:"mb-2 p-4 rounded" do %>
       <i class="fa-solid fa-magnifying-glass-plus"></i>
-      <span>香り診断</span>
+      <span><%= t('menu.diagnosis') %></span>
     <% end %>
   </li>
   <li>
     <%= link_to '#', class:"mb-2 p-4 rounded" do %>
       <i class="fa-solid fa-comments"></i>
-      <span>レビュー</span>
+      <span><%= t('menu.review') %></span>
     <% end %>
   </li>
 </ul>

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -25,6 +25,11 @@ ja:
     login: ログイン
     logout: ログアウト
     sign_up: アカウント登録
+  menu:
+    fragrance: マイ香水
+    calendar: カレンダー
+    diagnosis: 香り診断
+    review: レビュー
   fragrances:
     index:
       title: マイ香水一覧

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -39,6 +39,13 @@ ja:
       title: 記録カレンダー
     new:
       title: 新しく記録する
+    show:
+      title: カレンダー詳細
+      blank: (記録なし)
+      record: の記録
   simple_calendar:
     previous: "<<"
     next: ">>"
+  time:
+    formats:
+      japanese: "%-m月%-d日(%a)"


### PR DESCRIPTION
# 概要
カレンダー一覧画面で香水名またはボトル画像クリックで詳細へ

# 実施した内容
- 天気と気分の絵文字をFontAwesomeに置き換え
- コントローラーのshowアクション記述
- 詳細画面のビュー作成
- 一覧画面の香水名とボトル画像から詳細へのリンク
- サイドメニューのi18n化

# 補足
詳細画面は縦並びなので後で見た目整える

# 関連issue
#20 
