### PR TITLE
Feature/#28 マイ香水にステータス追加

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -64,3 +64,5 @@ gem "rails-i18n"
 gem "devise-i18n"
 
 gem "simple_calendar"
+
+gem "enum_help"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -113,6 +113,8 @@ GEM
       devise (>= 4.9.0)
       rails-i18n
     drb (2.2.1)
+    enum_help (0.0.19)
+      activesupport (>= 3.0.0)
     erubi (1.13.1)
     ffi (1.17.2-aarch64-linux-gnu)
     ffi (1.17.2-aarch64-linux-musl)
@@ -352,6 +354,7 @@ DEPENDENCIES
   debug
   devise
   devise-i18n
+  enum_help
   image_processing (~> 1.2)
   jbuilder
   jsbundling-rails

--- a/app/controllers/reviews_controller.rb
+++ b/app/controllers/reviews_controller.rb
@@ -9,6 +9,9 @@ class ReviewsController < ApplicationController
 
   def new
     @review = Review.new
+    if params[:fragrance_id]
+      @review.fragrance_id = params[:fragrance_id]
+    end
   end
 
   def create

--- a/app/models/fragrance.rb
+++ b/app/models/fragrance.rb
@@ -2,6 +2,8 @@ class Fragrance < ApplicationRecord
   validates :name, presence: true, length: { maximum: 100 }
   validates :brand, presence: true, length: { maximum: 50 }
 
+  enum status: { private: 0, public: 1 }
+
   belongs_to :user
   has_one_attached :image
   has_many :calendars, dependent: :destroy

--- a/app/models/fragrance.rb
+++ b/app/models/fragrance.rb
@@ -7,5 +7,5 @@ class Fragrance < ApplicationRecord
   belongs_to :user
   has_one_attached :image
   has_many :calendars, dependent: :destroy
-  has_many :reviews, dependent: :destroy
+  has_one :review, dependent: :destroy
 end

--- a/app/models/fragrance.rb
+++ b/app/models/fragrance.rb
@@ -2,7 +2,7 @@ class Fragrance < ApplicationRecord
   validates :name, presence: true, length: { maximum: 100 }
   validates :brand, presence: true, length: { maximum: 50 }
 
-  enum status: { private: 0, public: 1 }
+  enum status: { unpublished: 0, published: 1 }
 
   belongs_to :user
   has_one_attached :image

--- a/app/models/review.rb
+++ b/app/models/review.rb
@@ -4,4 +4,17 @@ class Review < ApplicationRecord
 
   validates :body, presence: true, length: { maximum: 1000 }
   validates :fragrance_id, uniqueness: { scope: :user_id, message: "はすでにレビュー済みです" }
+
+  after_create :make_fragrance_public
+  after_destroy :revert_fragrance_status
+
+  private
+
+  def make_fragrance_public
+    fragrance.update(status: :published) if fragrance.unpublished?
+  end
+
+  def revert_fragrance_status
+    fragrance.update(status: :unpublished)
+  end
 end

--- a/app/views/fragrances/_fragrance.html.erb
+++ b/app/views/fragrances/_fragrance.html.erb
@@ -1,0 +1,16 @@
+<li class="p-4 border rounded shadow-sm bg-white">
+  <strong><%= fragrance.brand %></strong> - <%= fragrance.name %>
+  <% if fragrance.published? %>
+    <i class="fas fa-globe text-blue-500" title="公開中"></i>
+  <% else %>
+    <i class="fas fa-lock text-gray-400" title="非公開"></i>
+  <% end %>
+  <div class="h-[200px] overflow-hidden mb-4">
+    <% if fragrance.image.attached? %>
+      <%= image_tag fragrance.image.variant(resize_to_limit: [300, 300]), class: "w-full h-full object-cover rounded shadow" %>
+    <% else %>
+      <%= image_tag "default_fragrance.png", class: "w-full h-full object-cover rounded shadow" %>
+    <% end %>
+  </div>
+  <%= link_to t('defaults.show'), fragrance_path(fragrance), class: "btn btn-sm" %>
+</li>

--- a/app/views/fragrances/index.html.erb
+++ b/app/views/fragrances/index.html.erb
@@ -5,7 +5,7 @@
   <ul class="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-6">
     <% @fragrances.each do |fragrance| %>
       <li class="p-4 border rounded shadow-sm bg-white">
-        <strong><%= fragrance.brand %></strong> - <%= fragrance.name %>
+        <strong><%= fragrance.brand %></strong> - <%= fragrance.name %>（<%= fragrance.status_i18n %>）
         <div class="h-[200px] overflow-hidden mb-4">
           <% if fragrance.image.attached? %>
             <%= image_tag fragrance.image.variant(resize_to_limit: [300, 300]), class: "w-full h-full object-cover rounded shadow" %>

--- a/app/views/fragrances/index.html.erb
+++ b/app/views/fragrances/index.html.erb
@@ -3,19 +3,7 @@
 
 <% if @fragrances.any? %>
   <ul class="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-6">
-    <% @fragrances.each do |fragrance| %>
-      <li class="p-4 border rounded shadow-sm bg-white">
-        <strong><%= fragrance.brand %></strong> - <%= fragrance.name %>（<%= fragrance.status_i18n %>）
-        <div class="h-[200px] overflow-hidden mb-4">
-          <% if fragrance.image.attached? %>
-            <%= image_tag fragrance.image.variant(resize_to_limit: [300, 300]), class: "w-full h-full object-cover rounded shadow" %>
-          <% else %>
-            <%= image_tag "default_fragrance.png", class: "w-full h-full object-cover rounded shadow" %>
-          <% end %>
-        </div>
-        <%= link_to t('defaults.show'), fragrance_path(fragrance), class: "btn btn-sm" %>
-      </li>
-    <% end %>
+    <%= render @fragrances %>
   </ul>
 <% else %>
   <p>まだ香水が登録されていません。</p>

--- a/app/views/fragrances/show.html.erb
+++ b/app/views/fragrances/show.html.erb
@@ -8,7 +8,11 @@
 <% else %>
   <%= image_tag "default_fragrance.png", class: "w-[300px] h-[240px] object-cover rounded shadow-md mb-4" %>
 <% end %>
-<p>レビュー公開設定：<%= @fragrance.status_i18n %></p>
+<p>レビュー公開設定：<%= @fragrance.status_i18n %><% if @fragrance.published? %>
+  <i class="fas fa-globe text-blue-500" title="公開中"></i>
+<% else %>
+  <i class="fas fa-lock text-gray-400" title="非公開"></i>
+<% end %></p>
 <% if @fragrance.unpublished? %>
   <%= link_to "レビューを書く", new_review_path(fragrance_id: @fragrance.id), class: "btn btn-primary mt-4" %>
 

--- a/app/views/fragrances/show.html.erb
+++ b/app/views/fragrances/show.html.erb
@@ -8,6 +8,7 @@
 <% else %>
   <%= image_tag "default_fragrance.png", class: "w-[300px] h-[240px] object-cover rounded shadow-md mb-4" %>
 <% end %>
+<p>公開設定：<%= @fragrance.status_i18n %></p>
 
 <div class="mt-4 space-x-2">
   <%= link_to t('defaults.edit'), edit_fragrance_path(@fragrance), class: "btn btn-outline" %>

--- a/app/views/fragrances/show.html.erb
+++ b/app/views/fragrances/show.html.erb
@@ -8,7 +8,13 @@
 <% else %>
   <%= image_tag "default_fragrance.png", class: "w-[300px] h-[240px] object-cover rounded shadow-md mb-4" %>
 <% end %>
-<p>公開設定：<%= @fragrance.status_i18n %></p>
+<p>レビュー公開設定：<%= @fragrance.status_i18n %></p>
+<% if @fragrance.unpublished? %>
+  <%= link_to "レビューを書く", new_review_path(fragrance_id: @fragrance.id), class: "btn btn-primary mt-4" %>
+
+<% elsif @fragrance.published? && (review = @fragrance.review) %>
+  <%= link_to "レビューを見る", review_path(review), class: "btn btn-outline" %>
+<% end %>
 
 <div class="mt-4 space-x-2">
   <%= link_to t('defaults.edit'), edit_fragrance_path(@fragrance), class: "btn btn-outline" %>

--- a/app/views/reviews/_form.html.erb
+++ b/app/views/reviews/_form.html.erb
@@ -1,4 +1,6 @@
-<% if current_user.fragrances.any? %>
+<% unpublished_fragrances = current_user.fragrances.unpublished %>
+
+<% if unpublished_fragrances.any? %>
   <%= form_with model: @review, local: true do |f| %>
     <% if @review.errors.any? %>
       <div class="bg-red-100 border border-red-400 text-red-700 px-4 py-2 rounded mb-4">
@@ -13,7 +15,7 @@
     <!-- 香水 -->
     <div class="mb-4">
       <%= f.label :fragrance_id, t('reviews.new.select'), class: "block font-semibold mb-1" %>
-      <%= f.collection_select :fragrance_id, current_user.fragrances, :id, :name, { prompt: "選択してください" }, class: "w-full border rounded p-2" %>
+      <%= f.collection_select :fragrance_id, current_user.fragrances.unpublished, :id, :name, { prompt: "選択してください" }, class: "w-full border rounded p-2" %>
     </div>
 
     <!-- レビュー本文 -->
@@ -28,6 +30,12 @@
       <%= f.submit class: "btn btn-primary" %>
     </div>
   <% end %>
+<% elsif current_user.fragrances.any? %>
+  <div class="bg-yellow-100 border border-yellow-400 text-yellow-700 px-4 py-3 rounded">
+    <p>すでにすべての香水がレビュー済みです。</p>
+    <p>新しい香水を登録するか、レビューを編集してください。</p>
+    <%= link_to "マイ香水を追加", new_fragrance_path, class: "underline text-blue-600 hover:text-blue-800" %>
+  </div>
 <% else %>
   <div class="bg-yellow-100 border border-yellow-400 text-yellow-700 px-4 py-3 rounded">
     <p>レビューを投稿するには、まずマイ香水を登録してください。</p>

--- a/app/views/reviews/_form.html.erb
+++ b/app/views/reviews/_form.html.erb
@@ -15,7 +15,14 @@
     <!-- 香水 -->
     <div class="mb-4">
       <%= f.label :fragrance_id, t('reviews.new.select'), class: "block font-semibold mb-1" %>
-      <%= f.collection_select :fragrance_id, current_user.fragrances.unpublished, :id, :name, { prompt: "選択してください" }, class: "w-full border rounded p-2" %>
+      <% if @review.fragrance_id.present? %>
+        <!-- fragrance_id がすでに指定されていれば、非表示の hidden_field にして固定 -->
+        <%= f.hidden_field :fragrance_id %>
+        <p><%= current_user.fragrances.find(@review.fragrance_id).name %> を選択中</p>
+      <% else %>
+        <!-- fragrance_id がなければ通常のセレクトボックス -->
+        <%= f.collection_select :fragrance_id, current_user.fragrances.unpublished, :id, :name, { prompt: "選択してください" }, class: "w-full border rounded p-2" %>
+      <% end %>
     </div>
 
     <!-- レビュー本文 -->

--- a/app/views/reviews/show.html.erb
+++ b/app/views/reviews/show.html.erb
@@ -38,7 +38,7 @@
   <div class="text-center mt-8">
     <% if current_user == @review.user %>
       <%= link_to t('defaults.edit'), edit_review_path(@review), class: "btn btn-outline" %>
-      <%= link_to t('defaults.delete'), review_path(@review), method: :delete, data: { confirm: t('defaults.delete_confirm') }, class: "btn btn-error" %>
+      <%= link_to t('defaults.delete'), review_path(@review), method: :delete, data: { confirm: "レビューを削除してもマイ香水は消えません" }, class: "btn btn-error" %>
     <% end %>
     <%= link_to t('defaults.back_index'), reviews_path, class: "text-sm text-gray-500 underline" %>
   </div>

--- a/config/locales/activerecord/ja.yml
+++ b/config/locales/activerecord/ja.yml
@@ -27,3 +27,8 @@ ja:
         body: レビュー本文
         fragrance_id: 香水
         fragrance: 香水
+  enums:
+    fragrance:
+      status:
+        unpublished: "非公開"
+        published: "公開中"

--- a/db/migrate/20250616083734_add_status_to_fragrances.rb
+++ b/db/migrate/20250616083734_add_status_to_fragrances.rb
@@ -1,0 +1,5 @@
+class AddStatusToFragrances < ActiveRecord::Migration[7.2]
+  def change
+    add_column :fragrances, :status, :integer, default: 0, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_06_15_112616) do
+ActiveRecord::Schema[7.2].define(version: 2025_06_16_083734) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -62,6 +62,7 @@ ActiveRecord::Schema[7.2].define(version: 2025_06_15_112616) do
     t.bigint "user_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.integer "status", default: 0, null: false
     t.index ["user_id"], name: "index_fragrances_on_user_id"
   end
 


### PR DESCRIPTION
# 概要
レビューの有無をマイ香水側でも公開・非公開で管理

# 実施した内容
- fragranceモデルにstatusカラム追加
- enumでunpublishedとpublishedに分ける。デフォルトは非公開
- マイ香水一覧・詳細画面に現在のステータスを表示
- レビュー投稿時にステータスを公開に、削除時に非公開に切り替え
- マイ香水詳細ページからレビューを書く場合、すでに香水を選択済みにする

# 補足
日本語表記のためgem enum_helpを導入

# 関連issue
