### PR TITLE
診断ページのi18n化

### DIFF
--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -26,10 +26,10 @@ class Users::SessionsController < Devise::SessionsController
   # end
 
   def after_sign_in_path_for(resource)
-    root_path
+    calendars_path
   end
 
   def after_sign_out_path_for(resource_or_scope)
-    new_user_session_path
+    root_path
   end
 end

--- a/app/views/diagnoses/new.html.erb
+++ b/app/views/diagnoses/new.html.erb
@@ -1,4 +1,5 @@
-<h1 class="text-3xl font-bold mb-6 text-center ">香り診断</h1>
+<% content_for(:title, t('.title')) %>
+<h1 class="text-3xl font-bold mb-6 text-center "><i class="fa-solid fa-magnifying-glass-plus"></i> <%= t('.title') %></h1>
 
 <%= form_with url: diagnosis_path, method: :post, class: "max-w-xl mx-auto bg-white p-6 rounded-lg shadow-md" do %>
 
@@ -17,6 +18,6 @@
   <% end %>
 
   <div class="flex justify-between items-center">
-    <%= submit_tag "診断する", class: "btn btn-primary" %>
+    <%= submit_tag t('.submit'), class: "btn btn-accent" %>
   </div>
 <% end %>

--- a/app/views/diagnoses/result.html.erb
+++ b/app/views/diagnoses/result.html.erb
@@ -1,5 +1,6 @@
+<% content_for(:title, t('.title')) %>
 <div class="max-w-4xl mx-auto p-6 bg-base-100 rounded-xl shadow-lg">
-  <h1 class="text-2xl font-bold text-center mb-6">あなたにおすすめの香りは…</h1>
+  <h1 class="text-2xl font-bold text-center mb-6"><%= t('.title') %></h1>
   <% if @result %>
     <div class="grid md:grid-cols-2 gap-6 items-center">
       <%= image_tag(@result[:image_path], alt: @result[:name], class: "w-full rounded-lg shadow-md") if @result[:image_path].present? %>
@@ -7,7 +8,7 @@
       <div>
         <h2 class="text-2xl font-semibold text-primary mb-2"><%= @result[:name] %></h2>
         <p class="mb-4 text-base-content"><%= @result[:description] %></p>
-        <p class="mb-2 font-semibold text-sm">代表的な香料:</p>
+        <p class="mb-2 font-semibold text-sm"><%= t('.note') %>:</p>
         <div class="flex flex-wrap gap-2">
           <% @result[:notes].each do |note| %>
             <span class="badge badge-accent"><%= note %></span>
@@ -16,10 +17,10 @@
       </div>
     </div>
   <% else %>
-    <p class="text-center text-error mt-4">診断結果が見つかりませんでした。</p>
+    <p class="text-center text-error mt-4"><%= t('.no_result') %></p>
   <% end %>
 
   <div class="text-center mt-8">
-    <%= link_to "もう一度診断する", new_diagnosis_path, class: "btn btn-outline btn-primary" %>
+    <%= link_to t('.again'), new_diagnosis_path, class: "btn btn-outline btn-primary" %>
   </div>
 </div>

--- a/app/views/shared/_menu.html.erb
+++ b/app/views/shared/_menu.html.erb
@@ -12,15 +12,15 @@
     <% end %>
   </li>
   <li>
-    <%= link_to new_diagnosis_path, class:"mb-2 p-4 rounded" do %>
-      <i class="fa-solid fa-magnifying-glass-plus"></i>
-      <span><%= t('menu.diagnosis') %></span>
-    <% end %>
-  </li>
-  <li>
     <%= link_to reviews_path, class:"mb-2 p-4 rounded" do %>
       <i class="fa-solid fa-comments"></i>
       <span><%= t('menu.review') %></span>
+    <% end %>
+  </li>
+  <li>
+    <%= link_to new_diagnosis_path, class:"mb-2 p-4 rounded" do %>
+      <i class="fa-solid fa-magnifying-glass-plus"></i>
+      <span><%= t('menu.diagnosis') %></span>
     <% end %>
   </li>
 </ul>

--- a/config/locales/activerecord/ja.yml
+++ b/config/locales/activerecord/ja.yml
@@ -22,7 +22,7 @@ ja:
         user_id: ""
         weather: 天気
         mood: 気分
-        memo: メモ
+        memo: ひとことメモ
       review:
         body: レビュー本文
         fragrance_id: 香水

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -28,7 +28,7 @@ ja:
     sign_up: アカウント登録
   menu:
     fragrance: マイ香水
-    calendar: カレンダー
+    calendar: 香り日記
     diagnosis: 香り診断
     review: レビュー
   fragrances:
@@ -42,15 +42,15 @@ ja:
       title: マイ香水編集
   calendars:
     index:
-      title: 記録カレンダー
+      title: 香り日記
     new:
       title: 新しく記録する
     show:
-      title: カレンダー詳細
+      title: 日記詳細
       blank: (記録なし)
       record: の記録
     edit:
-      title: カレンダー編集
+      title: 日記編集
   simple_calendar:
     previous: "<<"
     next: ">>"
@@ -67,3 +67,12 @@ ja:
       title: レビュー詳細
     edit:
       title: レビュー編集
+  diagnoses:
+    new:
+      title: 香り診断
+      submit: 自分に合う香りを見つける
+    result:
+      title: あなたにおすすめの香りは…
+      again: もう一度診断する
+      no_result: 診断結果が見つかりませんでした
+      note: 代表的な香料


### PR DESCRIPTION
# 概要
診断ページをi18n対応

# 実施した内容
- titleとsubmitの日本語化
- 左メニューの順番で診断を一番下に
- ログイン後の遷移先をカレンダー一覧に変更

# 補足

# 関連issue
