### PR TITLE
Feature/#34 レーダーチャート

### DIFF
--- a/app/assets/stylesheets/application.tailwind.css
+++ b/app/assets/stylesheets/application.tailwind.css
@@ -6,14 +6,14 @@
   prefersdark: false;
   color-scheme: "light";
   --color-base-100: oklch(97% 0.008 101.277);
-  --color-base-200: oklch(93% 0.008 101.277);
-  --color-base-300: oklch(94% 0.05 101.54);
+  --color-base-200: oklch(0.924 0.0086 128.56);
+  --color-base-300: oklch(0.7862 0.0526 146.8);
   --color-base-content: oklch(26% 0.05 172.552);
-  --color-primary: oklch(55% 0.118 165.612);
+  --color-primary: oklch(0.7862 0.0526 146.8);
   --color-primary-content: oklch(98% 0.02 120.757);
   --color-secondary: oklch(77.75% 0.17 111.09);
   --color-secondary-content: oklch(15.55% 0.039 111.09);
-  --color-accent: oklch(85.39% 0.15 100.73);
+  --color-accent: oklch(92% 0.12 95.746);
   --color-accent-content: oklch(17.078% 0.04 100.73);
   --color-neutral: oklch(45% 0.05 168.94);
   --color-neutral-content: oklch(90.196% 0.015 108.6);

--- a/app/controllers/fragrances_controller.rb
+++ b/app/controllers/fragrances_controller.rb
@@ -42,7 +42,7 @@ class FragrancesController < ApplicationController
   private
 
   def fragrance_params
-    params.require(:fragrance).permit(:name, :brand, :image)
+    params.require(:fragrance).permit(:name, :brand, :image, :sweetness, :freshness, :floral, :calm, :sexy, :spicy)
   end
 
   def set_fragrance

--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -1,5 +1,6 @@
 // Entry point for the build script in your package.json
 import "@hotwired/turbo-rails"
 import "./controllers"
+import "./chart"
 import Rails from "@rails/ujs"
 Rails.start()

--- a/app/javascript/chart.js
+++ b/app/javascript/chart.js
@@ -1,0 +1,31 @@
+import Chart from 'chart.js/auto';
+
+document.addEventListener("turbo:load", function () {
+  const ctx = document.getElementById("radarChart");
+  if (ctx) {
+    new Chart(ctx, {
+      type: 'radar',
+      data: {
+        labels: ["甘さ", "爽やかさ", "華やかさ", "落ち着き", "スパイシー", "セクシー"],
+        datasets: [{
+          label: "香りの印象（例）",
+          data: [3, 4, 2, 5, 1, 3],
+          backgroundColor: 'rgba(255, 99, 132, 0.2)',
+          borderColor: 'rgba(255, 99, 132, 1)',
+          borderWidth: 1
+        }]
+      },
+      options: {
+        scales: {
+          r: {
+            min: 0,
+            max: 5,
+            ticks: {
+              stepSize: 1
+            }
+          }
+        }
+      }
+    });
+  }
+});

--- a/app/javascript/chart.js
+++ b/app/javascript/chart.js
@@ -1,31 +1,3 @@
 import Chart from 'chart.js/auto';
 
-document.addEventListener("turbo:load", function () {
-  const ctx = document.getElementById("radarChart");
-  if (ctx) {
-    new Chart(ctx, {
-      type: 'radar',
-      data: {
-        labels: ["甘さ", "爽やかさ", "華やかさ", "落ち着き", "スパイシー", "セクシー"],
-        datasets: [{
-          label: "香りの印象（例）",
-          data: [3, 4, 2, 5, 1, 3],
-          backgroundColor: 'rgba(255, 99, 132, 0.2)',
-          borderColor: 'rgba(255, 99, 132, 1)',
-          borderWidth: 1
-        }]
-      },
-      options: {
-        scales: {
-          r: {
-            min: 0,
-            max: 5,
-            ticks: {
-              stepSize: 1
-            }
-          }
-        }
-      }
-    });
-  }
-});
+window.Chart = Chart;

--- a/app/models/fragrance.rb
+++ b/app/models/fragrance.rb
@@ -1,6 +1,9 @@
 class Fragrance < ApplicationRecord
   validates :name, presence: true, length: { maximum: 100 }
   validates :brand, presence: true, length: { maximum: 50 }
+  validates :sweetness, :freshness, :floral, :calm, :sexy, :spicy,
+          allow_nil: true,
+          numericality: { only_integer: true, greater_than: 0, less_than: 6 }
 
   enum status: { unpublished: 0, published: 1 }
 

--- a/app/views/calendars/edit.html.erb
+++ b/app/views/calendars/edit.html.erb
@@ -3,4 +3,4 @@
 
 <%= render "form", calendar: @calendar %>
 
-<%= link_to t('defaults.back'), calendars_path, class: "text-blue-500 underline mt-4 inline-block" %>
+<%= link_to t('defaults.back'), calendars_path, class: "btn btn-outline" %>

--- a/app/views/calendars/new.html.erb
+++ b/app/views/calendars/new.html.erb
@@ -3,4 +3,4 @@
 
 <%= render "form", calendar: @calendar %>
 
-<%= link_to t('defaults.back'), calendars_path, class: "text-blue-500 underline mt-4 inline-block" %>
+<%= link_to t('defaults.back'), calendars_path, class: "btn btn-outline" %>

--- a/app/views/fragrances/_form.html.erb
+++ b/app/views/fragrances/_form.html.erb
@@ -9,22 +9,98 @@
     </div>
   <% end %>
 
-  <div class="mb-4">
-    <%= form.label :brand, class: "block font-bold mb-1" %>
-    <%= form.text_field :brand, maxlength: 50, class: "border rounded w-full py-2 px-3" %>
-    <p class="text-sm text-gray-500">※50文字以内</p>
+  <!-- 横並びの2カラム -->
+  <div class="grid grid-cols-1 md:grid-cols-2 gap-6">
+    <!-- 左カラム：基本情報 -->
+    <div>
+      <div class="mb-4">
+        <%= form.label :brand, class: "block font-bold mb-1" %>
+        <%= form.text_field :brand, maxlength: 50, class: "border rounded w-full py-2 px-3" %>
+        <p class="text-sm text-gray-500">※50文字以内</p>
+      </div>
+
+      <div class="mb-4">
+        <%= form.label :name, class: "block font-bold mb-1" %>
+        <%= form.text_field :name, maxlength: 100, class: "border rounded w-full py-2 px-3" %>
+        <p class="text-sm text-gray-500">※100文字以内</p>
+      </div>
+
+      <div class="mb-4">
+        <%= form.label :image, class: "block font-bold mb-1" %>
+        <%= form.file_field :image, class: "file-input file-input-bordered w-full" %>
+      </div>
+    </div>
+
+    <!-- 右カラム：印象評価 -->
+    <div>
+      <h3 class="font-bold mb-2">香りの印象（1〜5、任意）
+        <span class="text-sm font-normal text-gray-500">(未入力でも登録できます)</span>
+      </h3>
+      <div class="flex justify-between text-sm text-gray-500 px-1">
+        <span>← 弱い</span>
+        <span>強い →</span>
+      </div>
+      <div class="flex justify-between text-xs text-gray-400 px-1 mb-2 select-none">
+        <% (1..5).each do |n| %>
+          <span><%= n %></span>
+        <% end %>
+      </div>
+
+      <div class="mb-4">
+        <%= form.label :sweetness, "甘さ", class: "block mb-1 font-bold" %>
+        <div class="flex items-center gap-2">
+          <%= form.range_field :sweetness, in: 1..5, class: "range range-accent w-full", step: 1, value: @fragrance.sweetness || 3 %>
+        </div>
+      </div>
+
+      <div class="mb-4">
+        <%= form.label :freshness, "爽やか", class: "block mb-1 font-bold" %>
+        <div class="flex items-center gap-2">
+          <%= form.range_field :freshness, in: 1..5, class: "range range-accent w-full", step: 1, value: @fragrance.freshness || 3 %>
+        </div>
+      </div>
+
+      <div class="mb-4">
+        <%= form.label :floral, "華やか", class: "block mb-1 font-bold" %>
+        <div class="flex items-center gap-2">
+          <%= form.range_field :floral, in: 1..5, class: "range range-accent w-full", step: 1, value: @fragrance.floral || 3 %>
+        </div>
+      </div>
+
+      <div class="mb-4">
+        <%= form.label :sexy, "セクシー", class: "block mb-1 font-bold" %>
+        <div class="flex items-center gap-2">
+          <%= form.range_field :sexy, in: 1..5, class: "range range-accent w-full", step: 1, value: @fragrance.sexy || 3 %>
+        </div>
+      </div>
+
+      <div class="mb-4">
+        <%= form.label :spicy, "スパイシー", class: "block mb-1 font-bold" %>
+        <div class="flex items-center gap-2">
+          <%= form.range_field :spicy, in: 1..5, class: "range range-accent w-full", step: 1, value: @fragrance.spicy || 3 %>
+        </div>
+      </div>
+
+      <div class="mb-4">
+        <%= form.label :calm, "落ち着き", class: "block mb-1 font-bold" %>
+        <div class="flex items-center gap-2">
+          <%= form.range_field :calm, in: 1..5, class: "range range-accent w-full", step: 1, value: @fragrance.calm || 3 %>
+        </div>
+      </div>
+    </div>
   </div>
 
-  <div class="mb-4">
-    <%= form.label :name, class: "block font-bold mb-1" %>
-    <%= form.text_field :name, maxlength: 100, class: "border rounded w-full py-2 px-3" %>
-    <p class="text-sm text-gray-500">※100文字以内</p>
-  </div>
+  <div class="mt-8 flex justify-between items-center">
+    <% if @fragrance.persisted? %>
+    <!-- editの場合: 詳細ページに戻る -->
+      <%= link_to t('defaults.back'), fragrance_path(@fragrance), class: "btn btn-outline" %>
+    <% else %>
+    <!-- newの場合: 一覧に戻る -->
+      <%= link_to t('defaults.back'), fragrances_path, class: "btn btn-outline" %>
+    <% end %>
 
-  <div class="mb-4">
-    <%= form.label :image, class: "block font-bold mb-1" %>
-    <%= form.file_field :image, class: "file-input file-input-bordered w-full" %>
+    <%= form.submit @fragrance.persisted? ? "更新する" : "登録する", class: "btn btn-primary" %>
   </div>
-
-  <%= form.submit class: "btn btn-primary" %>
 <% end %>
+
+

--- a/app/views/fragrances/_form.html.erb
+++ b/app/views/fragrances/_form.html.erb
@@ -47,42 +47,42 @@
       </div>
 
       <div class="mb-4">
-        <%= form.label :sweetness, "甘さ", class: "block mb-1 font-bold" %>
+        <%= form.label :sweetness, class: "block mb-1 font-bold" %>
         <div class="flex items-center gap-2">
           <%= form.range_field :sweetness, in: 1..5, class: "range range-accent w-full", step: 1, value: @fragrance.sweetness || 3 %>
         </div>
       </div>
 
       <div class="mb-4">
-        <%= form.label :freshness, "爽やか", class: "block mb-1 font-bold" %>
+        <%= form.label :freshness, class: "block mb-1 font-bold" %>
         <div class="flex items-center gap-2">
           <%= form.range_field :freshness, in: 1..5, class: "range range-accent w-full", step: 1, value: @fragrance.freshness || 3 %>
         </div>
       </div>
 
       <div class="mb-4">
-        <%= form.label :floral, "華やか", class: "block mb-1 font-bold" %>
+        <%= form.label :floral, class: "block mb-1 font-bold" %>
         <div class="flex items-center gap-2">
           <%= form.range_field :floral, in: 1..5, class: "range range-accent w-full", step: 1, value: @fragrance.floral || 3 %>
         </div>
       </div>
 
       <div class="mb-4">
-        <%= form.label :sexy, "セクシー", class: "block mb-1 font-bold" %>
+        <%= form.label :sexy, class: "block mb-1 font-bold" %>
         <div class="flex items-center gap-2">
           <%= form.range_field :sexy, in: 1..5, class: "range range-accent w-full", step: 1, value: @fragrance.sexy || 3 %>
         </div>
       </div>
 
       <div class="mb-4">
-        <%= form.label :spicy, "スパイシー", class: "block mb-1 font-bold" %>
+        <%= form.label :spicy, class: "block mb-1 font-bold" %>
         <div class="flex items-center gap-2">
           <%= form.range_field :spicy, in: 1..5, class: "range range-accent w-full", step: 1, value: @fragrance.spicy || 3 %>
         </div>
       </div>
 
       <div class="mb-4">
-        <%= form.label :calm, "落ち着き", class: "block mb-1 font-bold" %>
+        <%= form.label :calm, class: "block mb-1 font-bold" %>
         <div class="flex items-center gap-2">
           <%= form.range_field :calm, in: 1..5, class: "range range-accent w-full", step: 1, value: @fragrance.calm || 3 %>
         </div>

--- a/app/views/fragrances/edit.html.erb
+++ b/app/views/fragrances/edit.html.erb
@@ -2,5 +2,3 @@
 <h2><%= t('.title') %></h2>
 
 <%= render "form", fragrance: @fragrance %>
-
-<%= link_to t('defaults.back'), fragrance_path(@fragrance), class: "btn mt-4" %>

--- a/app/views/fragrances/new.html.erb
+++ b/app/views/fragrances/new.html.erb
@@ -2,5 +2,3 @@
 <h1><%= t('.title') %></h1>
 
 <%= render "form", fragrance: @fragrance %>
-
-<%= link_to t('defaults.back'), fragrances_path, class: "text-blue-500 underline mt-4 inline-block" %>

--- a/app/views/fragrances/show.html.erb
+++ b/app/views/fragrances/show.html.erb
@@ -1,24 +1,48 @@
 <% content_for(:title, @fragrance.name) %>
 <h1><%= t('.title') %></h1>
 
-<p><%= t('activerecord.attributes.fragrance.brand') %>: <%= @fragrance.brand %></p>
-<h2><%= t('activerecord.attributes.fragrance.name') %>： <%= @fragrance.name %></h2>
-<% if @fragrance.image.attached? %>
-  <%= image_tag @fragrance.image.variant(resize_to_limit: [300, 240]), class: "w-[300px] h-[240px] object-cover rounded shadow-md mb-4" %>
-<% else %>
-  <%= image_tag "default_fragrance.png", class: "w-[300px] h-[240px] object-cover rounded shadow-md mb-4" %>
-<% end %>
-<p>レビュー公開設定：<%= @fragrance.status_i18n %><% if @fragrance.published? %>
-  <i class="fas fa-globe text-blue-500" title="公開中"></i>
-<% else %>
-  <i class="fas fa-lock text-gray-400" title="非公開"></i>
-<% end %></p>
-<% if @fragrance.unpublished? %>
-  <%= link_to "レビューを書く", new_review_path(fragrance_id: @fragrance.id), class: "btn btn-primary mt-4" %>
+<div class="md:flex md:space-x-6">
+  <!-- 左側 -->
+  <div class="md:w-1/2">
+    <p><%= t('activerecord.attributes.fragrance.brand') %>: <%= @fragrance.brand %></p>
+    <h2><%= t('activerecord.attributes.fragrance.name') %>： <%= @fragrance.name %></h2>
 
-<% elsif @fragrance.published? && (review = @fragrance.review) %>
-  <%= link_to "レビューを見る", review_path(review), class: "btn btn-outline" %>
-<% end %>
+    <% if @fragrance.image.attached? %>
+      <%= image_tag @fragrance.image.variant(resize_to_limit: [300, 240]), class: "w-[300px] h-[240px] object-cover rounded shadow-md mb-4" %>
+    <% else %>
+      <%= image_tag "default_fragrance.png", class: "w-[300px] h-[240px] object-cover rounded shadow-md mb-4" %>
+    <% end %>
+
+    <p>レビュー公開設定：<%= @fragrance.status_i18n %>
+    <% if @fragrance.published? %>
+      <i class="fas fa-globe text-blue-500" title="公開中"></i>
+    <% else %>
+      <i class="fas fa-lock text-gray-400" title="非公開"></i>
+    <% end %></p>
+
+    <% if @fragrance.unpublished? %>
+      <%= link_to "レビューを書く", new_review_path(fragrance_id: @fragrance.id), class: "btn btn-primary mt-4" %>
+    <% elsif @fragrance.published? && (review = @fragrance.review) %>
+      <%= link_to "レビューを見る", review_path(review), class: "btn btn-outline" %>
+    <% end %>
+  </div>
+
+  <!-- 右側（チャート） -->
+  <div class="md:w-1/2 mt-6 md:mt-0">
+    <div class="p-4 border rounded bg-white shadow">
+      <%= render "shared/radar_chart",
+        chart_id: "fragrance_chart_#{@fragrance.id}",
+        data: [
+          @fragrance.sweetness,
+          @fragrance.freshness,
+          @fragrance.floral,
+          @fragrance.sexy,
+          @fragrance.spicy,
+          @fragrance.calm
+        ] %>
+    </div>
+  </div>
+</div>
 
 <div class="mt-4 space-x-2">
   <%= link_to t('defaults.edit'), edit_fragrance_path(@fragrance), class: "btn btn-outline" %>

--- a/app/views/reviews/show.html.erb
+++ b/app/views/reviews/show.html.erb
@@ -26,6 +26,18 @@
 
     <!-- 右側：レビュー本文 -->
     <div class="flex flex-col gap-4 w-full md:w-1/2">
+      <div class="p-4 border rounded bg-white shadow">
+        <%= render "shared/radar_chart",
+          chart_id: "fragrance_chart_#{@review.fragrance.id}",
+          data: [
+            @review.fragrance.sweetness,
+            @review.fragrance.freshness,
+            @review.fragrance.floral,
+            @review.fragrance.sexy,
+            @review.fragrance.spicy,
+            @review.fragrance.calm
+          ] %>
+      </div>
       <div>
         <p class="font-semibold mb-1"><%= t('activerecord.attributes.review.body') %></p>
           <div class="p-2 border rounded-md text-sm text-gray-800 bg-white">

--- a/app/views/shared/_radar_chart.html.erb
+++ b/app/views/shared/_radar_chart.html.erb
@@ -1,0 +1,40 @@
+<canvas id="<%= chart_id %>" width="400" height="400"></canvas>
+
+<script>
+  document.addEventListener("turbo:load", function () {
+    const ctx = document.getElementById("<%= chart_id %>");
+    if (!ctx) return;
+
+    if (Chart.getChart(ctx)) {
+      Chart.getChart(ctx).destroy();
+    }
+
+
+    new Chart(ctx, {
+      type: 'radar',
+      data: {
+        labels: ['甘さ', '爽やか', '華やか', 'セクシー', 'スパイシー', '落ち着き'],
+        datasets: [{
+          label: '香りの印象',
+          data: [<%= data.map(&:to_i).join(", ") %>],
+          backgroundColor: 'rgba(255, 99, 132, 0.2)',
+          borderColor: 'rgba(255, 99, 132, 1)',
+          borderWidth: 1,
+          pointBackgroundColor: 'rgba(255, 99, 132, 1)'
+        }]
+      },
+      options: {
+        responsive: true,
+        scales: {
+          r: {
+            min: 0,
+            max: 5,
+            ticks: {
+              stepSize: 1
+            }
+          }
+        }
+      }
+    });
+  });
+</script>

--- a/app/views/static_pages/top.html.erb
+++ b/app/views/static_pages/top.html.erb
@@ -5,3 +5,5 @@
 <button class="btn btn-primary">daisyUI</button>
 
 <button class="btn btn-secondary">btn btn-secondary</button>
+
+<canvas id="radarChart" width="400" height="400"></canvas>

--- a/app/views/static_pages/top.html.erb
+++ b/app/views/static_pages/top.html.erb
@@ -5,5 +5,3 @@
 <button class="btn btn-primary">daisyUI</button>
 
 <button class="btn btn-secondary">btn btn-secondary</button>
-
-<canvas id="radarChart" width="400" height="400"></canvas>

--- a/config/locales/activerecord/ja.yml
+++ b/config/locales/activerecord/ja.yml
@@ -14,7 +14,7 @@ ja:
       fragrance:
         name: 香水名
         brand: ブランド名
-        image: ボトル画像
+        image: ボトル画像(任意)
       calendar:
         start_time: 日付
         fragrance_id: 使用した香水
@@ -22,7 +22,7 @@ ja:
         user_id: ""
         weather: 天気
         mood: 気分
-        memo: ひとことメモ
+        memo: ひとこと日記
       review:
         body: レビュー本文
         fragrance_id: 香水

--- a/config/locales/activerecord/ja.yml
+++ b/config/locales/activerecord/ja.yml
@@ -15,6 +15,12 @@ ja:
         name: 香水名
         brand: ブランド名
         image: ボトル画像(任意)
+        sweetness: 甘さ
+        freshness: 爽やか
+        floral: 華やか
+        sexy: セクシー
+        spicy: スパイシー
+        calm: 落ち着き
       calendar:
         start_time: 日付
         fragrance_id: 使用した香水

--- a/db/migrate/20250619015916_add_impression_fields_to_fragrances.rb
+++ b/db/migrate/20250619015916_add_impression_fields_to_fragrances.rb
@@ -1,0 +1,10 @@
+class AddImpressionFieldsToFragrances < ActiveRecord::Migration[7.2]
+  def change
+    add_column :fragrances, :sweetness, :integer
+    add_column :fragrances, :freshness, :integer
+    add_column :fragrances, :floral, :integer
+    add_column :fragrances, :calm, :integer
+    add_column :fragrances, :sexy, :integer
+    add_column :fragrances, :spicy, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_06_16_083734) do
+ActiveRecord::Schema[7.2].define(version: 2025_06_19_015916) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -63,6 +63,12 @@ ActiveRecord::Schema[7.2].define(version: 2025_06_16_083734) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.integer "status", default: 0, null: false
+    t.integer "sweetness"
+    t.integer "freshness"
+    t.integer "floral"
+    t.integer "calm"
+    t.integer "sexy"
+    t.integer "spicy"
     t.index ["user_id"], name: "index_fragrances_on_user_id"
   end
 

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "@hotwired/turbo-rails": "^8.0.13",
     "@rails/ujs": "^7.1.3-4",
     "@tailwindcss/cli": "^4.1.4",
+    "chart.js": "^4.5.0",
     "daisyui": "^5.0.27",
     "tailwindcss": "^4.1.4"
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -167,6 +167,11 @@
   resolved "https://registry.yarnpkg.com/@hotwired/turbo/-/turbo-8.0.13.tgz#ab35fda9d358432c8a872a833844b38cccb8c25b"
   integrity sha512-M7qXUqcGab6G5PKOiwhgbByTtrPgKPFCTMNQ52QhzUEXEqmp0/ApEguUesh/FPiUjrmFec+3lq98KsWnYY2C7g==
 
+"@kurkle/color@^0.3.0":
+  version "0.3.4"
+  resolved "https://registry.yarnpkg.com/@kurkle/color/-/color-0.3.4.tgz#4d4ff677e1609214fc71c580125ddddd86abcabf"
+  integrity sha512-M5UknZPHRu3DEDWoipU6sE8PdkZ6Z/S+v4dD+Ke8IaNlpdSQah50lz1KtcFBa2vsdOnwbbnxJwVM4wty6udA5w==
+
 "@napi-rs/wasm-runtime@^0.2.8":
   version "0.2.9"
   resolved "https://registry.yarnpkg.com/@napi-rs/wasm-runtime/-/wasm-runtime-0.2.9.tgz#7278122cf94f3b36d8170a8eee7d85356dfa6a96"
@@ -396,6 +401,13 @@ braces@^3.0.3:
   integrity sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==
   dependencies:
     fill-range "^7.1.1"
+
+chart.js@^4.5.0:
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/chart.js/-/chart.js-4.5.0.tgz#11a1ef6c4befc514b1b0b613ebac226c4ad2740b"
+  integrity sha512-aYeC/jDgSEx8SHWZvANYMioYMZ2KX02W6f6uVfyteuCGcadDLcYVHdfdygsTQkQ4TKn5lghoojAsPj5pu0SnvQ==
+  dependencies:
+    "@kurkle/color" "^0.3.0"
 
 daisyui@^5.0.27:
   version "5.0.27"


### PR DESCRIPTION
# 概要
マイ香水に香りの印象レーダーチャートを追加

# 実施した内容
- chart.jsインストール
- fragranceモデルにsweetness,freshness,floral,spicy,sexy,calmカラムinteger型で追加
- コントローラーのparamsで受け取れるように
- マイ香水登録フォームに香りの印象６項目を１〜５でスライダーで入力
- マイ香水詳細・レビュー詳細画面にレーダーチャート表示

# 補足
未入力の場合はそのままのグラフが表示される
編集も可能

# 関連issue
#34 
