### PR TITLE
Feature/#71 一覧画面のページネーション

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -69,3 +69,5 @@ gem "enum_help"
 
 gem "aws-sdk-s3", require: false
 gem "dotenv-rails"
+
+gem "kaminari"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -165,6 +165,18 @@ GEM
     jsbundling-rails (1.3.1)
       railties (>= 6.0.0)
     json (2.10.2)
+    kaminari (1.2.2)
+      activesupport (>= 4.1.0)
+      kaminari-actionview (= 1.2.2)
+      kaminari-activerecord (= 1.2.2)
+      kaminari-core (= 1.2.2)
+    kaminari-actionview (1.2.2)
+      actionview
+      kaminari-core (= 1.2.2)
+    kaminari-activerecord (1.2.2)
+      activerecord
+      kaminari-core (= 1.2.2)
+    kaminari-core (1.2.2)
     language_server-protocol (3.17.0.4)
     lint_roller (1.1.0)
     logger (1.7.0)
@@ -383,6 +395,7 @@ DEPENDENCIES
   image_processing (~> 1.2)
   jbuilder
   jsbundling-rails
+  kaminari
   pg (~> 1.1)
   puma (>= 5.0)
   rails (~> 7.2.1)

--- a/app/controllers/fragrances_controller.rb
+++ b/app/controllers/fragrances_controller.rb
@@ -2,7 +2,7 @@ class FragrancesController < ApplicationController
   before_action :set_fragrance, only: [ :show, :edit, :update, :destroy ]
 
   def index
-    @fragrances = current_user.fragrances
+    @fragrances = current_user.fragrances.order(created_at: :desc).page(params[:page])
   end
 
   def new

--- a/app/controllers/reviews_controller.rb
+++ b/app/controllers/reviews_controller.rb
@@ -4,7 +4,7 @@ class ReviewsController < ApplicationController
   before_action :authorize_user!, only: [ :edit, :update, :destroy ]
 
   def index
-    @reviews = Review.includes(:fragrance, :user).order(created_at: :desc)
+    @reviews = Review.includes(:fragrance, :user).order(created_at: :desc).page(params[:page])
   end
 
   def new

--- a/app/views/fragrances/index.html.erb
+++ b/app/views/fragrances/index.html.erb
@@ -3,7 +3,7 @@
 
 <% if @fragrances.any? %>
   <ul class="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-6">
-    <%= render @fragrances %>
+    <%= render partial: "fragrance", collection: @fragrances %>
   </ul>
 <% else %>
   <p>まだ香水が登録されていません。</p>

--- a/app/views/fragrances/index.html.erb
+++ b/app/views/fragrances/index.html.erb
@@ -10,3 +10,4 @@
 <% end %>
 
 <%= link_to "香水を登録する", new_fragrance_path, class: "btn btn-primary" %>
+<%= paginate @fragrances %>

--- a/app/views/kaminari/_first_page.html.erb
+++ b/app/views/kaminari/_first_page.html.erb
@@ -1,0 +1,11 @@
+<%# Link to the "First" page
+  - available local variables
+    url:           url to the first page
+    current_page:  a page object for the currently displayed page
+    total_pages:   total number of pages
+    per_page:      number of items to fetch per page
+    remote:        data-remote
+-%>
+<span class="first">
+  <%= link_to_unless current_page.first?, t('views.pagination.first').html_safe, url, remote: remote %>
+</span>

--- a/app/views/kaminari/_gap.html.erb
+++ b/app/views/kaminari/_gap.html.erb
@@ -1,0 +1,8 @@
+<%# Non-link tag that stands for skipped pages...
+  - available local variables
+    current_page:  a page object for the currently displayed page
+    total_pages:   total number of pages
+    per_page:      number of items to fetch per page
+    remote:        data-remote
+-%>
+<span class="page gap"><%= t('views.pagination.truncate').html_safe %></span>

--- a/app/views/kaminari/_last_page.html.erb
+++ b/app/views/kaminari/_last_page.html.erb
@@ -1,0 +1,11 @@
+<%# Link to the "Last" page
+  - available local variables
+    url:           url to the last page
+    current_page:  a page object for the currently displayed page
+    total_pages:   total number of pages
+    per_page:      number of items to fetch per page
+    remote:        data-remote
+-%>
+<span class="last">
+  <%= link_to_unless current_page.last?, t('views.pagination.last').html_safe, url, remote: remote %>
+</span>

--- a/app/views/kaminari/_next_page.html.erb
+++ b/app/views/kaminari/_next_page.html.erb
@@ -1,0 +1,11 @@
+<%# Link to the "Next" page
+  - available local variables
+    url:           url to the next page
+    current_page:  a page object for the currently displayed page
+    total_pages:   total number of pages
+    per_page:      number of items to fetch per page
+    remote:        data-remote
+-%>
+<span class="next">
+  <%= link_to_unless current_page.last?, t('views.pagination.next').html_safe, url, class: "join-item btn", rel: 'next', remote: remote %>
+</span>

--- a/app/views/kaminari/_page.html.erb
+++ b/app/views/kaminari/_page.html.erb
@@ -1,0 +1,10 @@
+<%# Link showing page number
+  - available local variables
+    page:          a page object for "this" page
+    url:           url to this page
+    current_page:  a page object for the currently displayed page
+    total_pages:   total number of pages
+    per_page:      number of items to fetch per page
+    remote:        data-remote
+-%>
+<%= link_to page, url, class: "join-item btn #{'btn-active' if page.current?}", rel: page.rel %>

--- a/app/views/kaminari/_paginator.html.erb
+++ b/app/views/kaminari/_paginator.html.erb
@@ -1,0 +1,23 @@
+<%# The container tag
+  - available local variables
+    current_page:  a page object for the currently displayed page
+    total_pages:   total number of pages
+    per_page:      number of items to fetch per page
+    remote:        data-remote
+    paginator:     the paginator that renders the pagination tags inside
+-%>
+<div class="join text-xs mt-8 mx-auto flex justify-center">
+  <%= paginator.render do -%>
+    <nav class="pagination" role="navigation" aria-label="pager">
+      <%= prev_page_tag unless current_page.first? %>
+      <% each_page do |page| -%>
+        <% if page.display_tag? -%>
+          <%= page_tag page %>
+        <% end -%>
+      <% end -%>
+      <% unless current_page.out_of_range? %>
+        <%= next_page_tag unless current_page.last? %>
+      <% end %>
+    </nav>
+  <% end -%>
+</div>

--- a/app/views/kaminari/_prev_page.html.erb
+++ b/app/views/kaminari/_prev_page.html.erb
@@ -1,0 +1,11 @@
+<%# Link to the "Previous" page
+  - available local variables
+    url:           url to the previous page
+    current_page:  a page object for the currently displayed page
+    total_pages:   total number of pages
+    per_page:      number of items to fetch per page
+    remote:        data-remote
+-%>
+<span class="prev">
+  <%= link_to_unless current_page.first?, t('views.pagination.previous').html_safe, url, class: "join-item btn", rel: 'prev', remote: remote %>
+</span>

--- a/app/views/reviews/index.html.erb
+++ b/app/views/reviews/index.html.erb
@@ -12,3 +12,4 @@
 <% end %>
 
 <%= link_to t("reviews.new.title"), new_review_path, class: "btn btn-primary" %>
+<%= paginate @reviews %>

--- a/config/initializers/kaminari_config.rb
+++ b/config/initializers/kaminari_config.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+Kaminari.configure do |config|
+  config.default_per_page = 12
+  # config.max_per_page = nil
+  config.window = 2
+  # config.outer_window = 0
+  # config.left = 0
+  # config.right = 0
+  # config.page_method_name = :page
+  # config.param_name = :page
+  # config.max_pages = nil
+  # config.params_on_first_page = false
+end

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -1,4 +1,8 @@
 ja:
+  views:
+    pagination:
+      previous: "前へ"
+      next: "次へ"
   helpers:
       submit:
         create: 登録


### PR DESCRIPTION
# 概要
マイ香水・レビュー一覧で香水が１２件以上の時ページネーション

# 実施した内容
- gem kaminariのインストール
- configで１ページの表示上限を１２件に
- コントローラーのindexアクションにページネーション記述
- 一覧画面のビューに記述
- デザインをdaisyUIで調整

# 補足
現在は香水カードは横３縦４の１２件（横４でもいいかも）

# 関連issue
#71 