### PR TITLE
fix:一覧画面の文字位置修正

### DIFF
--- a/app/views/fragrances/_fragrance.html.erb
+++ b/app/views/fragrances/_fragrance.html.erb
@@ -14,10 +14,8 @@
 
   <!-- ブランド名・香水名 -->
   <div class="flex flex-grow flex-col px-3 mt-4">
-    <div class="flex items-start space-x-2 justify-start">
-      <h2 class="font-bold flex-grow text-gray-500"><%= fragrance.brand %></h2>
-      <span class="text-lg font-bold"><%= fragrance.name %></span>
-    </div>
+    <p class="text-sm text-gray-500 font-semibold"><%= fragrance.brand %></p>
+    <p class="text-xl font-bold"><%= fragrance.name %></p>
   </div>
 
   <!-- 公開・非公開アイコン -->

--- a/app/views/reviews/_review.html.erb
+++ b/app/views/reviews/_review.html.erb
@@ -15,10 +15,8 @@
 
   <!-- ブランド名・香水名 -->
   <div class="flex flex-grow flex-col px-3 mt-4">
-    <div class="flex items-start space-x-2 justify-start">
-      <h2 class="font-bold flex-grow text-gray-500"><%= fragrance.brand %></h2>
-      <span class="text-lg font-bold"><%= fragrance.name %></span>
-    </div>
+    <p class="text-sm text-gray-500 font-semibold"><%= fragrance.brand %></p>
+    <p class="text-xl font-bold"><%= fragrance.name %></p>
   </div>
 
   <p class="line-clamp-3 text-sm text-gray-800 mb-2">


### PR DESCRIPTION
# 概要
マイ香水・みんなの香水一覧でブランド名と香水名の位置が崩れる問題を修正

# 実施した内容
- ブランド名と香水名を縦並びに

# 補足
本番環境とローカルで見た目が違っていた

# 関連issue
#79 