### PR TITLE
Feature/#29 プロフィールページ

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -100,7 +100,7 @@ GEM
     bindex (0.8.1)
     bootsnap (1.18.4)
       msgpack (~> 1.2)
-    brakeman (7.0.2)
+    brakeman (7.1.0)
       racc
     builder (3.3.0)
     capybara (3.40.0)

--- a/app/controllers/profiles_controller.rb
+++ b/app/controllers/profiles_controller.rb
@@ -1,0 +1,5 @@
+class ProfilesController < ApplicationController
+  def show
+    @user = current_user
+  end
+end

--- a/app/helpers/profiles_helper.rb
+++ b/app/helpers/profiles_helper.rb
@@ -1,0 +1,2 @@
+module ProfilesHelper
+end

--- a/app/views/profiles/show.html.erb
+++ b/app/views/profiles/show.html.erb
@@ -1,0 +1,36 @@
+<% content_for(:title, t('.title')) %>
+
+<section class="px-4 py-12 sm:px-6 lg:px-8">
+  <h1 class="text-3xl font-bold mb-6 text-center">
+    <i class="fa-solid fa-house-chimney-user"></i>
+    <%= t('.title') %>
+  </h1>
+
+  <div class="max-w-md w-full mx-auto bg-white p-4 sm:p-6 rounded-xl shadow-lg">
+    <!-- ユーザー情報 -->
+    <div class="space-y-4">
+      <div>
+        <label class="block font-semibold text-gray-700 mb-1">
+          <i class="fa-solid fa-user"></i> ユーザー名
+        </label>
+        <p class="p-3 text-lg text-gray-800">
+          <%= @user.name %>
+        </p>
+      </div>
+
+      <div>
+        <label class="block font-semibold text-gray-700 mb-1">
+          <i class="fa-solid fa-envelope"></i> メールアドレス
+        </label>
+        <p class="p-3 text-lg text-gray-800">
+          <%= @user.email %>
+        </p>
+      </div>
+    </div>
+
+    <!-- 編集ボタンなど -->
+    <div class="mt-6">
+      <%= link_to "プロフィール編集", "#", class: "btn btn-primary w-full" %>
+    </div>
+  </div>
+</section>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -5,7 +5,7 @@
     <div class="flex-none space-x-2">
       <% if user_signed_in? %>
         <span class="text-sm font-semibold">
-          <%= current_user.name %>さん
+          <%= link_to "#{current_user.name}さん", profile_path, class: "hover:underline" %>
         </span>
         <%= link_to destroy_user_session_path, method: :delete, data: { turbo: false }, class: "btn btn-outline" do %>
           <i class="fa-solid fa-right-from-bracket"></i>

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -82,3 +82,6 @@ ja:
       review: みんなのおすすめ香水を見る
       no_result: 診断結果が見つかりませんでした
       note: 代表的な香料
+  profiles:
+    show:
+      title: プロフィール

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -10,6 +10,8 @@ Rails.application.routes.draw do
   resource :diagnosis, only: [ :new, :create ] do
     get :result
   end
+
+  resource :profile, only: %i[show]
   # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html
 
   # Reveal health status on /up that returns 200 if the app boots with no exceptions, otherwise 500.

--- a/test/controllers/profiles_controller_test.rb
+++ b/test/controllers/profiles_controller_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class ProfilesControllerTest < ActionDispatch::IntegrationTest
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
# 概要
マイページ（プロフィールページ）を表示

# 実施した内容
- profireのルーティング追加
- profilesコントローラー作成しshowアクション追加
- views/profiles/show.html.erb作成しユーザー名とメアドを表示
- ヘッダーのユーザー名から遷移

# 補足
- 未ログインでは閲覧不可
- 他人のプロフィールは見られない
- プロフィールへのリンクは名前ではなくプロフィール画像に変更予定

# 関連issue
#29 