### PR TITLE
fix:renderヘルスチェック設定

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -4,6 +4,6 @@ class ApplicationController < ActionController::Base
   before_action :authenticate_user!
 
   def health
-    render json: { status: 'ok', timestamp: Time.current }, status: :ok
+    render json: { status: "ok", timestamp: Time.current }, status: :ok
   end
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -2,4 +2,8 @@ class ApplicationController < ActionController::Base
   # Only allow modern browsers supporting webp images, web push, badges, import maps, CSS nesting, and CSS :has.
   allow_browser versions: :modern
   before_action :authenticate_user!
+
+  def health
+    render json: { status: 'ok', timestamp: Time.current }, status: :ok
+  end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -12,6 +12,8 @@ Rails.application.routes.draw do
   end
 
   resource :profile, only: %i[show]
+
+  get '/health', to: 'application#health'
   # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html
 
   # Reveal health status on /up that returns 200 if the app boots with no exceptions, otherwise 500.

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -13,7 +13,7 @@ Rails.application.routes.draw do
 
   resource :profile, only: %i[show]
 
-  get '/health', to: 'application#health'
+  get "/health", to: "application#health"
   # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html
 
   # Reveal health status on /up that returns 200 if the app boots with no exceptions, otherwise 500.


### PR DESCRIPTION
# 概要
renderデプロイがタイムアウトするためヘルスチェックの設定

# 実施した内容
- render側でHealth Check Path: /health に設定
- routes.rbに get '/health', to: 'application#health' を追加
- app/controllers/application_controller.rbにもhealthメソッドを追加

# 補足

# 関連issue
