### PR TITLE
fix:ヘルスチェックでは認証をスキップする

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,7 +1,7 @@
 class ApplicationController < ActionController::Base
   # Only allow modern browsers supporting webp images, web push, badges, import maps, CSS nesting, and CSS :has.
   allow_browser versions: :modern
-  before_action :authenticate_user!
+  before_action :authenticate_user!, except: [ :health ]
 
   def health
     render json: { status: "ok", timestamp: Time.current }, status: :ok


### PR DESCRIPTION
# 概要
ヘルスチェックで401が返り続けてしまう問題

# 実施した内容
- application_controllerのbefore_action :authenticate_user!をヘルスチェックの時はスキップするよう記述

# 補足

# 関連issue
