### PR TITLE
Feature/#31 プロフィール編集

### DIFF
--- a/app/controllers/profiles_controller.rb
+++ b/app/controllers/profiles_controller.rb
@@ -1,5 +1,5 @@
 class ProfilesController < ApplicationController
-  before_action :set_user, only: [ :show :edit, :update ]
+  before_action :set_user, only: [ :show, :edit, :update ]
 
   def show
   end
@@ -9,9 +9,9 @@ class ProfilesController < ApplicationController
 
   def update
     if @user.update(profile_params)
-      redirect_to profile_path, success: t("defaults.flash_message.updated", item: User.model_name.human)
+      redirect_to profile_path, notice: t("defaults.flash_message.updated", item: User.model_name.human)
     else
-      flash.now[:danger] = t("defaults.flash_message.not_updated", item: User.model_name.human)
+      flash.now[:alert] = t("defaults.flash_message.not_updated", item: User.model_name.human)
       render :edit, status: :unprocessable_entity
     end
   end

--- a/app/controllers/profiles_controller.rb
+++ b/app/controllers/profiles_controller.rb
@@ -1,5 +1,28 @@
 class ProfilesController < ApplicationController
+  before_action :set_user, only: [ :show :edit, :update ]
+
   def show
+  end
+
+  def edit
+  end
+
+  def update
+    if @user.update(profile_params)
+      redirect_to profile_path, success: t("defaults.flash_message.updated", item: User.model_name.human)
+    else
+      flash.now[:danger] = t("defaults.flash_message.not_updated", item: User.model_name.human)
+      render :edit, status: :unprocessable_entity
+    end
+  end
+
+  private
+
+  def set_user
     @user = current_user
+  end
+
+  def profile_params
+    params.require(:user).permit(:name, :email)
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -7,4 +7,6 @@ class User < ApplicationRecord
   has_many :fragrances, dependent: :destroy
   has_many :calendars, dependent: :destroy
   has_many :reviews, dependent: :destroy
+
+  validates :name, presence: true, length: { maximum: 255 }
 end

--- a/app/views/profiles/edit.html.erb
+++ b/app/views/profiles/edit.html.erb
@@ -1,0 +1,35 @@
+<% content_for(:title, t('.title')) %>
+
+<section class="px-4 py-12 sm:px-6 lg:px-8">
+  <h1 class="text-3xl font-bold mb-6 text-center">
+    <i class="fa-solid fa-pen"></i>
+    <%= t('.title') %>
+  </h1>
+
+  <div class="max-w-md w-full mx-auto bg-white p-4 sm:p-6 rounded-xl shadow-lg">
+    <%= form_with model: @user, url: profile_path, method: :put do |f| %>
+      <%= render "devise/shared/error_messages", resource: @user %>
+
+      <!-- 名前 -->
+      <div>
+        <label class="block font-semibold mb-1">
+          <i class="fa-solid fa-user"></i> ユーザー名 <span class="text-red-500">*</span>
+        </label>
+        <%= f.text_field :name, autofocus: true, class: "w-full p-3 border border-gray-300 rounded-md shadow-sm", placeholder: "表示名を入力してください" %>
+      </div>
+
+      <!-- メール -->
+      <div>
+        <label class="block font-semibold mb-1">
+          <i class="fa-solid fa-envelope"></i> メールアドレス <span class="text-red-500">*</span>
+        </label>
+        <%= f.email_field :email, autocomplete: "email", class: "w-full p-3 border border-gray-300 rounded-md shadow-sm", placeholder: "メールアドレスを入力してください" %>
+      </div>
+
+      <!-- ボタン -->
+      <div class="mt-8 flex justify-between items-center">
+        <%= link_to t('defaults.back'), profile_path, class: "btn btn-outline" %>
+        <%= f.submit "更新する", class: "btn btn-primary" %>
+      </div>
+    <% end %>
+</section>

--- a/app/views/profiles/show.html.erb
+++ b/app/views/profiles/show.html.erb
@@ -28,9 +28,12 @@
       </div>
     </div>
 
-    <!-- 編集ボタンなど -->
+    <!-- 編集ボタン -->
     <div class="mt-6">
-      <%= link_to "プロフィール編集", "#", class: "btn btn-primary w-full" %>
+      <%= link_to  edit_profile_path, class: "btn btn-primary w-full" do %>
+        <i class="fa-solid fa-pen"></i>
+        プロフィールを編集
+      <% end %>
     </div>
   </div>
 </section>

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -85,6 +85,8 @@ ja:
   profiles:
     show:
       title: プロフィール
+    edit:
+      title: プロフィール編集
   static_pages:
     terms_of_service:
       title: 利用規約

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -11,7 +11,7 @@ Rails.application.routes.draw do
     get :result
   end
 
-  resource :profile, only: %i[show]
+  resource :profile, only: %i[show edit update]
 
   get "/health", to: "application#health"
   # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html


### PR DESCRIPTION
# 概要
プロフィールページから名前とメアドを編集できるようにしました

# 実施した内容
- プロフィールのedit,updateのルーティングとコントローラー追加
- 編集ページのビュー作成
- プロフィールページからリンク
- 名前とメールアドレスが更新できることを確認
- user.rbで名前にバリデーション追加

# 補足
更新後のメアドとパスワードでログインできることを確認しました

# 関連issue
