### PR TITLE
Feature/#98 レビュー検索機能

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -73,3 +73,5 @@ gem "dotenv-rails"
 gem "kaminari"
 
 gem "active_storage_validations"
+
+gem "ransack"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -287,6 +287,10 @@ GEM
       zeitwerk (~> 2.6)
     rainbow (3.1.1)
     rake (13.2.1)
+    ransack (4.3.0)
+      activerecord (>= 6.1.5)
+      activesupport (>= 6.1.5)
+      i18n
     rdoc (6.13.1)
       psych (>= 4.0.0)
     regexp_parser (2.10.0)
@@ -407,6 +411,7 @@ DEPENDENCIES
   puma (>= 5.0)
   rails (~> 7.2.1)
   rails-i18n
+  ransack
   rubocop-rails-omakase
   selenium-webdriver
   simple_calendar

--- a/app/controllers/reviews_controller.rb
+++ b/app/controllers/reviews_controller.rb
@@ -4,7 +4,8 @@ class ReviewsController < ApplicationController
   before_action :authorize_user!, only: [ :edit, :update, :destroy ]
 
   def index
-    @reviews = Review.includes(:fragrance, :user).order(created_at: :desc).page(params[:page])
+    @q = Review.ransack(params[:q])
+    @reviews = @q.result(distinct: true).includes(:fragrance, :user).order(created_at: :desc).page(params[:page])
   end
 
   def new

--- a/app/models/fragrance.rb
+++ b/app/models/fragrance.rb
@@ -11,4 +11,13 @@ class Fragrance < ApplicationRecord
   has_one_attached :image
   has_many :calendars, dependent: :destroy
   has_one :review, dependent: :destroy
+
+  # ransack用の検索設定
+  def self.ransackable_attributes(auth_object = nil)
+    %w[name brand]
+  end
+
+  def self.ransackable_associations(auth_object = nil)
+    %w[reviews]
+  end
 end

--- a/app/models/review.rb
+++ b/app/models/review.rb
@@ -10,11 +10,11 @@ class Review < ApplicationRecord
 
   # ransackの検索設定
   def self.ransackable_attributes(auth_object = nil)
-    %w[]
+    %w[body]
   end
 
   def self.ransackable_associations(auth_object = nil)
-    %w[fragrances users]
+    %w[fragrance user]
   end
 
   private

--- a/app/models/review.rb
+++ b/app/models/review.rb
@@ -8,6 +8,15 @@ class Review < ApplicationRecord
   after_create :make_fragrance_public
   after_destroy :revert_fragrance_status
 
+  # ransackの検索設定
+  def self.ransackable_attributes(auth_object = nil)
+    %w[]
+  end
+
+  def self.ransackable_associations(auth_object = nil)
+    %w[fragrances users]
+  end
+
   private
 
   def make_fragrance_public

--- a/app/views/reviews/_search_form.html.erb
+++ b/app/views/reviews/_search_form.html.erb
@@ -1,0 +1,33 @@
+<div class="card mb-6 shadow-lg">
+  <div class="card-body">
+    <h2 class="card-title text-lg mb-4">
+      <i class="fas fa-search mr-2"></i>
+      レビューを検索
+    </h2>
+
+    <%= search_form_for q, url: reviews_path, method: :get, class: "space-y-4" do |f| %>
+      <div class="form-control">
+        <%= f.label :fragrance_name_or_fragrance_brand_cont, "香水名・ブランド名", class: "label" %>
+        <div class="input-group">
+          <%= f.search_field :fragrance_name_or_fragrance_brand_cont,
+              class: "input input-bordered flex-1",
+              placeholder: "検索ワードを入力(香水名・ブランド名)" %>
+          <button type="submit" class="btn btn-primary">
+            <i class="fas fa-search"></i>
+            検索
+          </button>
+        </div>
+      </div>
+
+      <!-- 検索条件がある場合のクリアボタン -->
+      <% if params[:q].present? %>
+        <div class="text-center">
+          <%= link_to reviews_path, class: "btn btn-outline btn-sm" do %>
+            <i class="fas fa-times mr-1"></i>
+            検索条件をクリア
+          </button>
+        </div>
+      <% end %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/reviews/_search_form.html.erb
+++ b/app/views/reviews/_search_form.html.erb
@@ -1,47 +1,45 @@
-<div class="card mb-6 shadow-lg">
-  <div class="card-body">
-    <h2 class="card-title text-lg mb-4">
-      <i class="fas fa-search mr-2"></i>
-      レビューを検索
-    </h2>
+<div class="flex justify-center px-4 sm:px-6 md:px-8 mt-6">
+  <div class="w-full max-w-5xl space-y-4 p-6 bg-white backdrop-blur-md rounded-lg shadow-lg mb-4">
 
     <%= search_form_for q, url: reviews_path, method: :get, class: "space-y-4", local: true do |f| %>
       <div class="form-control">
         <%= f.label :fragrance_name_or_fragrance_brand_cont, "香水名・ブランド名", class: "label" %>
-        <div class="input-group">
+        <div class="flex gap-2">
           <%= f.search_field :fragrance_name_or_fragrance_brand_cont,
-              class: "input input-bordered flex-1",
+              class: "input input-bordered flex-1 w-full p-3 border border-gray-300 rounded-xl shadow-sm",
               placeholder: "検索ワードを入力" %>
+          <!-- 検索ボタンを横並びに -->
           <button type="submit" class="btn btn-primary">
             <i class="fas fa-search"></i>
             検索
           </button>
         </div>
       </div>
-
-      <!-- 検索条件がある場合のクリアボタン -->
-      <% if params[:q].present? %>
-        <div class="text-center">
-          <%= link_to reviews_path, class: "btn btn-outline btn-sm" do %>
-            <i class="fas fa-times mr-1"></i>
-            検索条件をクリア
-          </button>
-        </div>
-      <% end %>
     <% end %>
 
-    <!-- 検索結果の件数表示 -->
-      <% if params[:q].present? %>
-        <div class="alert alert-info">
+    <!-- 検索状態の表示エリア -->
+    <% if params[:q].present? %>
+      <div class="flex flex-col sm:flex-row sm:justify-between sm:items-center gap-2">
+        <!-- 検索結果の件数表示 -->
+        <div class="alert alert-info flex-1">
           <i class="fa-solid fa-info-circle"></i>
           <span>
             検索結果: <strong><%= @reviews.total_count %></strong>件
-            <% if params[:q][:fragrance_name_or_fragrance_brand_name_cont].present? %>
-              （「<strong><%= params[:q][:fragrance_name_or_fragrance_brand_name_cont] %></strong>」を含む）
+            <% if params[:q][:fragrance_name_or_fragrance_brand_cont].present? %>
+              （「<strong><%= params[:q][:fragrance_name_or_fragrance_brand_cont] %></strong>」を含む）
             <% end %>
           </span>
         </div>
-      <% end %>
+
+        <!-- 検索条件をクリアするボタン -->
+        <div>
+          <%= link_to reviews_path, class: "btn btn-outline btn-sm" do %>
+            <i class="fas fa-times mr-1"></i>
+            検索条件をクリア
+          <% end %>
+        </div>
+      </div>
     <% end %>
+
   </div>
 </div>

--- a/app/views/reviews/_search_form.html.erb
+++ b/app/views/reviews/_search_form.html.erb
@@ -5,13 +5,13 @@
       レビューを検索
     </h2>
 
-    <%= search_form_for q, url: reviews_path, method: :get, class: "space-y-4" do |f| %>
+    <%= search_form_for q, url: reviews_path, method: :get, class: "space-y-4", local: true do |f| %>
       <div class="form-control">
         <%= f.label :fragrance_name_or_fragrance_brand_cont, "香水名・ブランド名", class: "label" %>
         <div class="input-group">
           <%= f.search_field :fragrance_name_or_fragrance_brand_cont,
               class: "input input-bordered flex-1",
-              placeholder: "検索ワードを入力(香水名・ブランド名)" %>
+              placeholder: "検索ワードを入力" %>
           <button type="submit" class="btn btn-primary">
             <i class="fas fa-search"></i>
             検索
@@ -26,6 +26,20 @@
             <i class="fas fa-times mr-1"></i>
             検索条件をクリア
           </button>
+        </div>
+      <% end %>
+    <% end %>
+
+    <!-- 検索結果の件数表示 -->
+      <% if params[:q].present? %>
+        <div class="alert alert-info">
+          <i class="fa-solid fa-info-circle"></i>
+          <span>
+            検索結果: <strong><%= @reviews.total_count %></strong>件
+            <% if params[:q][:fragrance_name_or_fragrance_brand_name_cont].present? %>
+              （「<strong><%= params[:q][:fragrance_name_or_fragrance_brand_name_cont] %></strong>」を含む）
+            <% end %>
+          </span>
         </div>
       <% end %>
     <% end %>

--- a/app/views/reviews/index.html.erb
+++ b/app/views/reviews/index.html.erb
@@ -10,13 +10,34 @@
   <% end %>
 </div>
 
+<%= render "search_form", q: @q %>
+
 <% if @reviews.any? %>
   <ul class="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-6">
     <%= render partial: "review", collection: @reviews %>
   </ul>
 <% else %>
   <div class="flex justify-center items-center w-full py-10">
-    <p class="text-gray-600 text-xl font-bold text-center">みんなの香水はありません。</p>
+    <% if params[:q].present? && params[:q].values.any?(&:present?) %>
+      <!-- 検索を行ったが結果が0件の場合 -->
+      <div class="text-center">
+        <i class="fa-solid fa-magnifying-glass text-4xl text-gray-400 mb-4"></i>
+        <p class="text-gray-600 text-xl font-bold mb-2">検索結果が見つかりませんでした</p>
+        <p class="text-gray-500">別のキーワードで検索してみてください</p>
+        <%= link_to "検索をクリア", reviews_path, class: "btn btn-secondary mt-4" %>
+      </div>
+    <% else %>
+      <!-- まだレビューが投稿されていない場合 -->
+      <div class="text-center">
+        <i class="fa-solid fa-comments text-4xl text-gray-400 mb-4"></i>
+        <p class="text-gray-600 text-xl font-bold mb-2">まだレビューがありません</p>
+        <p class="text-gray-500">最初のレビューを投稿してみませんか？</p>
+        <%= link_to new_review_path, class: "btn btn-primary mt-4" do %>
+          <i class="fa-solid fa-circle-plus"></i>
+          <span>レビューを書く</span>
+        <% end %>
+      </div>
+    <% end %>
   </div>
 <% end %>
 

--- a/app/views/reviews/index.html.erb
+++ b/app/views/reviews/index.html.erb
@@ -24,7 +24,6 @@
         <i class="fa-solid fa-magnifying-glass text-4xl text-gray-400 mb-4"></i>
         <p class="text-gray-600 text-xl font-bold mb-2">検索結果が見つかりませんでした</p>
         <p class="text-gray-500">別のキーワードで検索してみてください</p>
-        <%= link_to "検索をクリア", reviews_path, class: "btn btn-secondary mt-4" %>
       </div>
     <% else %>
       <!-- まだレビューが投稿されていない場合 -->


### PR DESCRIPTION
# 概要
レビュー一覧において、香水名orブランド名で検索可能に
検索結果がない時は「ありません」と表示

# 実施した内容
- gem ransackのインストール
- reviewsコントローラーのindexアクションで検索できるよう変更
- reviewモデルとfragranceモデルに検索可能なカラムを記述
- _search_form.html.erbを作成
- review/index.html.erbで検索フォームを表示

# 補足
タグ検索も追加予定、レビュー本文の検索は検討

# 関連issue
#98 