### PR TITLE
fix:プライバシポリシーと利用規約ページのログインチェックをスキップするよう設定

### DIFF
--- a/app/controllers/static_pages_controller.rb
+++ b/app/controllers/static_pages_controller.rb
@@ -1,5 +1,5 @@
 class StaticPagesController < ApplicationController
-  skip_before_action :authenticate_user!, only: [ :top ]
+  skip_before_action :authenticate_user!, only: [ :top, :terms_of_service, :privacy_policy ]
 
   def top
   end


### PR DESCRIPTION
# 概要
ログインしないと見られないようになっていたので修正

# 実施した内容
- static_pagesコントローラーでauthenticate_userをスキップする設定に変更

# 補足

# 関連issue
#134 