### PR TITLE
Feature/#105 コメント削除

### DIFF
--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -1,4 +1,7 @@
 class CommentsController < ApplicationController
+  before_action :set_comment, only: [:destroy]
+  before_action :authorize_user!, only: [:destroy]
+
   def create
     @review = Review.find(params[:review_id])
     @comment = @review.comments.build(comment_params)
@@ -11,9 +14,22 @@ class CommentsController < ApplicationController
     end
   end
 
+  def destroy
+    @comment.destroy!
+    redirect_to @comment.review, notice: t("defaults.flash_message.deleted", item: Comment.model_name.human)
+  end
+
   private
+
+  def set_comment
+    @comment = Comment.find(params[:id])
+  end
 
   def comment_params
     params.require(:comment).permit(:body)
+  end
+
+  def authorize_user!
+    redirect_to @comment.review, alert: t("defaults.flash_message.not_authorized") unless unless current_user.own?(@comment)
   end
 end

--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -30,6 +30,8 @@ class CommentsController < ApplicationController
   end
 
   def authorize_user!
-    redirect_to @comment.review, alert: t("defaults.flash_message.not_authorized") unless unless current_user.own?(@comment)
+    unless current_user.own?(@comment)
+      redirect_to @comment.review, alert: t("defaults.flash_message.not_authorized")
+    end
   end
 end

--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -22,7 +22,7 @@ class CommentsController < ApplicationController
   private
 
   def set_comment
-    @comment = Comment.find(params[:id])
+    @comment = current_user.comments.find(params[:id])
   end
 
   def comment_params

--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -1,6 +1,6 @@
 class CommentsController < ApplicationController
-  before_action :set_comment, only: [:destroy]
-  before_action :authorize_user!, only: [:destroy]
+  before_action :set_comment, only: [ :destroy ]
+  before_action :authorize_user!, only: [ :destroy ]
 
   def create
     @review = Review.find(params[:review_id])

--- a/app/controllers/reviews_controller.rb
+++ b/app/controllers/reviews_controller.rb
@@ -26,6 +26,8 @@ class ReviewsController < ApplicationController
   end
 
   def show
+  @comments = @review.comments.includes(:user).order(created_at: :desc)
+  @comment = Comment.new
   end
 
   def edit

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -15,4 +15,8 @@ class User < ApplicationRecord
   validates :profile_image, content_type: { in: %w[image/jpeg image/gif image/png] },
                           size: { less_than: 5.megabytes },
                           if: -> { profile_image.attached? }
+
+  def own?(object)
+    id == object.user_id
+  end
 end

--- a/app/views/comments/_comment.html.erb
+++ b/app/views/comments/_comment.html.erb
@@ -7,7 +7,7 @@
               alt: comment.user.name,
               class: "w-full h-full object-cover rounded-full" %>
       <% else %>
-        <div class="bg-gray-400 text-white rounded-full w-6 h-6 flex items-center justify-center">
+        <div class="bg-neutral text-neutral-content rounded-full w-6 h-6 flex items-center justify-center">
           <i class="fa-solid fa-user text-xs"></i>
         </div>
       <% end %>
@@ -27,17 +27,16 @@
         </div>
 
         <!-- 右側：編集・削除ボタン -->
-        <% if current_user.own?(comment) %>
-          <div class="flex items-center space-x-1 opacity-0 group-hover:opacity-100 transition-opacity duration-200">
-            <%= link_to review_comment_path(comment),
-                  method: :delete,
-                  data: {
-                    turbo_method: :delete,
-                    turbo_confirm: "本当に削除しますか？"
-                  },
-                  class: "text-red-500 hover:text-red-700 p-1 rounded hover:bg-red-50 transition-colors duration-200",
-                  title: "削除" do %>
-              <i class="fas fa-trash-alt" style="color: #f4a69e;" ></i>
+        <% if current_user && current_user.own?(comment) %>
+          <div class="flex items-center space-x-1">
+            <%= link_to comment_path(comment),
+              data: {
+                turbo_method: :delete,
+                turbo_confirm: "本当に削除しますか？"
+              },
+              class: "text-red-500 hover:text-red-700 p-1 rounded hover:bg-red-50 transition-colors duration-200",
+              title: "削除" do %>
+              <i class="fas fa-trash-alt" style="color: #f4a69e;"></i>
             <% end %>
           </div>
         <% end %>

--- a/app/views/comments/_comment.html.erb
+++ b/app/views/comments/_comment.html.erb
@@ -15,15 +15,35 @@
 
     <!-- コンテンツ -->
     <div class="flex-1">
-      <div class="flex items-baseline space-x-2">
-        <span class="text-sm font-medium text-gray-900">
-          <%= comment.user.name.presence || "匿名" %>
-        </span>
-        <span class="text-xs text-gray-500">
-          <%= time_ago_in_words(comment.created_at) %>前
-        </span>
+      <div class="flex items-baseline justify-between">
+        <!-- 左側：ユーザー情報 -->
+        <div class="flex items-baseline space-x-2">
+          <span class="text-sm font-medium text-gray-900">
+            <%= comment.user.name.presence || "匿名" %>
+          </span>
+          <span class="text-xs text-gray-500">
+            <%= time_ago_in_words(comment.created_at) %>前
+          </span>
+        </div>
+
+        <!-- 右側：編集・削除ボタン -->
+        <% if current_user.own?(comment) %>
+          <div class="flex items-center space-x-1 opacity-0 group-hover:opacity-100 transition-opacity duration-200">
+            <%= link_to review_comment_path(comment),
+                  method: :delete,
+                  data: {
+                    turbo_method: :delete,
+                    turbo_confirm: "本当に削除しますか？"
+                  },
+                  class: "text-red-500 hover:text-red-700 p-1 rounded hover:bg-red-50 transition-colors duration-200",
+                  title: "削除" do %>
+              <i class="fas fa-trash-alt" style="color: #f4a69e;" ></i>
+            <% end %>
+          </div>
+        <% end %>
       </div>
 
+      <!-- コメント本文 -->
       <div class="text-sm text-gray-700">
         <% limit = request.user_agent.match?(/Mobile/) ? 100 : 200 %>
         <% if comment.body.length > limit %>

--- a/app/views/comments/_form.html.erb
+++ b/app/views/comments/_form.html.erb
@@ -2,7 +2,7 @@
   <% if user_signed_in? %>
     <div id="comment_form">
       <%= form_with(model: [review, Comment.new], local: true, class: "flex flex-col space-y-2") do |f| %>
-        <div class="bg-gray-100 rounded shadow-sm">
+        <div class="bg-gray-100 rounded-lg shadow-sm">
           <%= f.text_area :body,
                 placeholder: "コメントを入力してください",
                 rows: 1,

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,7 +7,7 @@ Rails.application.routes.draw do
   resources :fragrances
   resources :calendars
   resources :reviews do
-    resources :comments, only: [ :create, :destroy ]
+    resources :comments, only: [ :create, :destroy ], shallow: true
   end
   resource :diagnosis, only: [ :new, :create ] do
     get :result

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,7 +7,7 @@ Rails.application.routes.draw do
   resources :fragrances
   resources :calendars
   resources :reviews do
-    resources :comments, only: [ :create ]
+    resources :comments, only: [ :create, :destroy ]
   end
   resource :diagnosis, only: [ :new, :create ] do
     get :result


### PR DESCRIPTION
# 概要
自分の投稿したコメントのみ削除できるように

# 実施した内容
- destroyのルーティング追加（shallow: true） 
- commentコントローラーでdestroyアクション記述
- 自分の投稿したコメントかチェックするためにuser.rbにown?メソッド作成
- コメントの右側に削除ボタン（ゴミ箱アイコン）設置

# 補足
Ajaxはまだ

# 関連issue
#105 