### PR TITLE
Feature/#101 ハンバーガーメニュー

### DIFF
--- a/app/assets/stylesheets/application.tailwind.css
+++ b/app/assets/stylesheets/application.tailwind.css
@@ -1,6 +1,15 @@
 @import "tailwindcss";
 @plugin "daisyui";
 
+/* ブレークポイントの設定 */
+@theme {
+  --breakpoint-sm: 640px;
+  --breakpoint-md: 768px;
+  --breakpoint-lg: 1024px;
+  --breakpoint-xl: 1280px;
+  --breakpoint-2xl: 1536px;
+}
+
 @plugin "daisyui/theme" {
   name: "lemonade";
   default: false;

--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -5,6 +5,7 @@ import "./chart"
 import Rails from "@rails/ujs"
 Rails.start()
 
+// コメント非同期
 function toggleComment(commentId) {
   const shortVersion = document.getElementById(`comment-body-${commentId}`);
   const fullVersion = document.getElementById(`comment-full-${commentId}`);
@@ -20,4 +21,33 @@ function toggleComment(commentId) {
   }
 }
 
+// ハンバーガーメニュー
+function toggleMenu() {
+  const menu = document.getElementById('mobile-menu');
+  if (menu) {
+    menu.classList.toggle('hidden');
+
+    if (menu.classList.contains('hidden')) {
+      document.body.style.overflow = '';
+    } else {
+      document.body.style.overflow = 'hidden';
+    }
+  }
+}
+
+// メニュー外クリックで閉じる
+document.addEventListener('DOMContentLoaded', function() {
+  document.addEventListener('click', function(event) {
+    const menu = document.getElementById('mobile-menu');
+    const menuButton = event.target.closest('button[onclick="toggleMenu()"]');
+
+    if (menu && !menu.classList.contains('hidden') && !menuButton && !menu.contains(event.target)) {
+      menu.classList.add('hidden');
+      document.body.style.overflow = '';
+    }
+  });
+});
+
+
 window.toggleComment = toggleComment;
+window.toggleMenu = toggleMenu;

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -31,12 +31,24 @@
       <%= render 'shared/header' %>
 
       <div class="flex flex-1">
-      <%= render 'shared/menu' %> <!-- 左メニュー -->
-      <main class="flex-1 px-4 py-6">
-        <%= render "shared/flash_messages" %>
-        <%= yield %>
-      </main>
-    </div>
+        <!-- デスクトップ: 常時表示 -->
+        <div class="hidden md:block">
+          <%= render 'shared/menu' %>
+        </div>
+
+        <!-- モバイル用メニュー -->
+        <div id="mobile-menu" class="fixed inset-0 z-50 md:hidden hidden">
+          <div class="fixed inset-0 bg-black opacity-50" onclick="toggleMenu()"></div>
+          <div class="fixed left-0 top-0 h-full w-64 bg-white shadow-lg">
+            <%= render 'shared/menu' %>
+          </div>
+        </div>
+
+        <main class="flex-1 px-4 py-6">
+          <%= render "shared/flash_messages" %>
+          <%= yield %>
+        </main>
+      </div>
 
       <%= render 'shared/footer' %>
     </div>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -32,14 +32,14 @@
 
       <div class="flex flex-1">
         <!-- デスクトップ: 常時表示 -->
-        <div class="hidden md:block">
+        <div class="hidden md:block w-48 bg-[#e4e7e1] shadow-sm">
           <%= render 'shared/menu' %>
         </div>
 
         <!-- モバイル用メニュー -->
         <div id="mobile-menu" class="fixed inset-0 z-50 md:hidden hidden">
           <div class="fixed inset-0 bg-black opacity-50" onclick="toggleMenu()"></div>
-          <div class="fixed left-0 top-0 h-full w-64 bg-white shadow-lg">
+          <div class="fixed left-0 top-0 h-full w-64 bg-[#e4e7e1] shadow-lg">
             <%= render 'shared/menu' %>
           </div>
         </div>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -1,8 +1,8 @@
 <header class="navbar bg-base-300 px-4 shadow-sm">
   <!-- ハンバーガーボタン（左端） -->
   <div class="navbar-start">
-    <button class="btn btn-ghost btn-sm" onclick="toggleMenu()">
-      <i class="fas fa-bars text-lg" aria-hidden="true"></i>
+    <button class="btn btn-ghost btn-sm md:hidden" onclick="toggleMenu()">
+      <i class="fas fa-bars text-lg"></i>
     </button>
   </div>
 

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -1,13 +1,13 @@
 <header class="navbar bg-base-300 px-4 shadow-sm">
-  <!-- モバイル用ハンバーガーボタン（左端） -->
+  <!-- ハンバーガーボタン（左端） -->
   <div class="navbar-start">
-    <button class="btn btn-ghost btn-sm md:hidden" onclick="toggleMenu()">
-      <i class="fas fa-bars text-lg"></i>
+    <button class="btn btn-ghost btn-sm" onclick="toggleMenu()">
+      <i class="fas fa-bars text-lg" aria-hidden="true"></i>
     </button>
   </div>
 
     <!-- ロゴ -->
-  <div class="navar-center">
+  <div class="navbar-center">
     <%= link_to "FragranceLog", root_path, class: "text-2xl font-bold" %>
   </div>
 

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -1,8 +1,18 @@
 <header class="navbar bg-base-300 px-4 shadow-sm">
-  <div class="flex-1">
+  <!-- モバイル用ハンバーガーボタン（左端） -->
+  <div class="navbar-start">
+    <button class="btn btn-ghost btn-sm md:hidden" onclick="toggleMenu()">
+      <i class="fas fa-bars text-lg"></i>
+    </button>
+  </div>
+
+    <!-- ロゴ -->
+  <div class="navar-center">
     <%= link_to "FragranceLog", root_path, class: "text-2xl font-bold" %>
   </div>
-  <div class="flex-none space-x-2">
+
+  <!-- 右側のユーザーメニュー -->
+  <div class="navbar-end space-x-2">
     <% if user_signed_in? %>
       <!-- プロフィールドロップダウン -->
       <div class="dropdown dropdown-end">

--- a/app/views/shared/_menu.html.erb
+++ b/app/views/shared/_menu.html.erb
@@ -1,4 +1,4 @@
-<ul class="menu md:flex flex-col w-48 p-4 bg-[#e4e7e1] text-base-content">
+<ul class="menu md:flex flex-col w-full p-4 text-base-content h-full">
   <li>
     <%= link_to fragrances_path, class:"mb-2 p-4 rounded" do %>
       <i class="fa-solid fa-spray-can-sparkles"></i>


### PR DESCRIPTION
# 概要
モバイル版ではサイドメニューが常にあると邪魔なのでハンバーガーメニューに

# 実施した内容
- application.html.erbでメニューを画面幅によって出し分け
- ヘッダーにハンバーガーメニューの３本線を表示（モバイル版）
- メニュー開閉のための関数をjavascriptで実装
- 画面幅による制御のためtailwind.cssにブレイクポイントの設定

# 補足
デスクトップ版でもメニュー開閉可能にするか検討

# 関連issue
#101 