### PR TITLE
独自ドメインを設定

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -99,4 +99,7 @@ Rails.application.configure do
   # ]
   # Skip DNS rebinding protection for the default health check endpoint.
   # config.host_authorization = { exclude: ->(request) { request.path == "/up" } }
+  config.hosts << "fragrance.com"      # 独自ドメイン
+  config.hosts << "www.fragrance.com"  # wwwサブドメイン
+  config.hosts << "fragrancelog.onrender.com"
 end


### PR DESCRIPTION
# 概要
独自ドメイン（fragrancelog.com）を設定します

# 実施した内容
- お名前.comでドメイン名取得
- renderのsettingで独自ドメインを入力し、A レコードの IP アドレス や CNAME のターゲット を控える
- お名前.comでDNSレコード設定し、A レコードの追加（ルートドメイン用）とCNAME レコードの追加（www 付きドメイン用）
- config/environments/production.rbで独自ドメインをホワイトリストに追加

# 補足

# 関連issue
#88 