### PR TITLE
Feature/#86 香水のタグ付け

### DIFF
--- a/app/controllers/fragrances_controller.rb
+++ b/app/controllers/fragrances_controller.rb
@@ -42,7 +42,7 @@ class FragrancesController < ApplicationController
   private
 
   def fragrance_params
-    params.require(:fragrance).permit(:name, :brand, :image, :sweetness, :freshness, :floral, :calm, :sexy, :spicy)
+    params.require(:fragrance).permit(:name, :brand, :image, :sweetness, :freshness, :floral, :calm, :sexy, :spicy, tag_ids: [])
   end
 
   def set_fragrance

--- a/app/controllers/fragrances_controller.rb
+++ b/app/controllers/fragrances_controller.rb
@@ -2,7 +2,7 @@ class FragrancesController < ApplicationController
   before_action :set_fragrance, only: [ :show, :edit, :update, :destroy ]
 
   def index
-    @fragrances = current_user.fragrances.order(created_at: :desc).page(params[:page])
+    @fragrances = current_user.fragrances.includes(:tags).order(created_at: :desc).page(params[:page])
   end
 
   def new

--- a/app/controllers/fragrances_controller.rb
+++ b/app/controllers/fragrances_controller.rb
@@ -46,6 +46,6 @@ class FragrancesController < ApplicationController
   end
 
   def set_fragrance
-    @fragrance = current_user.fragrances.find(params[:id])
+    @fragrance = current_user.fragrances.includes(:tags).find(params[:id])
   end
 end

--- a/app/controllers/reviews_controller.rb
+++ b/app/controllers/reviews_controller.rb
@@ -5,7 +5,7 @@ class ReviewsController < ApplicationController
 
   def index
     @q = Review.ransack(params[:q])
-    @reviews = @q.result(distinct: true).includes([:user, fragrance: :tags]).order(created_at: :desc).page(params[:page])
+    @reviews = @q.result(distinct: true).includes([ :user, fragrance: :tags ]).order(created_at: :desc).page(params[:page])
   end
 
   def new
@@ -50,7 +50,7 @@ class ReviewsController < ApplicationController
   private
 
   def set_review
-    @review = Review.includes([:user, fragrance: :tags]).find(params[:id])
+    @review = Review.includes([ :user, fragrance: :tags ]).find(params[:id])
   end
 
   def review_params

--- a/app/controllers/reviews_controller.rb
+++ b/app/controllers/reviews_controller.rb
@@ -5,7 +5,7 @@ class ReviewsController < ApplicationController
 
   def index
     @q = Review.ransack(params[:q])
-    @reviews = @q.result(distinct: true).includes(:fragrance, :user, :tags).order(created_at: :desc).page(params[:page])
+    @reviews = @q.result(distinct: true).includes([:user, fragrance: :tags]).order(created_at: :desc).page(params[:page])
   end
 
   def new
@@ -50,7 +50,7 @@ class ReviewsController < ApplicationController
   private
 
   def set_review
-    @review = Review.find(params[:id])
+    @review = Review.includes([:user, fragrance: :tags]).find(params[:id])
   end
 
   def review_params

--- a/app/controllers/reviews_controller.rb
+++ b/app/controllers/reviews_controller.rb
@@ -5,7 +5,7 @@ class ReviewsController < ApplicationController
 
   def index
     @q = Review.ransack(params[:q])
-    @reviews = @q.result(distinct: true).includes(:fragrance, :user).order(created_at: :desc).page(params[:page])
+    @reviews = @q.result(distinct: true).includes(:fragrance, :user, :tags).order(created_at: :desc).page(params[:page])
   end
 
   def new

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -7,4 +7,13 @@ module ApplicationHelper
       base_title
     end
   end
+
+  #タグ表示用
+  def display_tags(fragrance)
+    return content_tag(:span, "カテゴリ未設定", class: "text-gray-500 text-sm") if fragrance.tags.empty?
+
+    fragrance.tags.map do |tag|
+      content_tag :span, tag.name, class: "inline-block bg-accent text-xs px-2 py-1 rounded-full mr-1 mb-1"
+    end.join.html_safe
+  end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -8,7 +8,7 @@ module ApplicationHelper
     end
   end
 
-  #タグ表示用
+  # タグ表示用
   def display_tags(fragrance)
     return content_tag(:span, "カテゴリ未設定", class: "text-gray-500 text-sm") if fragrance.tags.empty?
 

--- a/app/helpers/fragrances_helper.rb
+++ b/app/helpers/fragrances_helper.rb
@@ -1,9 +1,2 @@
 module FragrancesHelper
-  def display_tags(fragrance)
-    return content_tag(:span, "未設定", class: "text-gray-500 text-sm") if fragrance.tags.empty?
-
-    fragrance.tags.map do |tag|
-      content_tag :span, tag.name, class: "inline-block bg-blue-100 text-blue-800 text-xs px-2 py-1 rounded-full mr-1 mb-1"
-    end.join.html_safe
-  end
 end

--- a/app/helpers/fragrances_helper.rb
+++ b/app/helpers/fragrances_helper.rb
@@ -1,2 +1,9 @@
 module FragrancesHelper
+  def display_tags(fragrance)
+    return content_tag(:span, "未設定", class: "text-gray-500 text-sm") if fragrance.tags.empty?
+
+    fragrance.tags.map do |tag|
+      content_tag :span, tag.name, class: "inline-block bg-blue-100 text-blue-800 text-xs px-2 py-1 rounded-full mr-1 mb-1"
+    end.join.html_safe
+  end
 end

--- a/app/models/fragrance.rb
+++ b/app/models/fragrance.rb
@@ -30,7 +30,7 @@ class Fragrance < ApplicationRecord
   # タグの数を最大3つに制限
   def tags_count_within_limit
     if tags.size > 3
-      errors.add(:tags, 'は3つまでしか選択できません')
+      errors.add(:tags, "は3つまでしか選択できません")
     end
   end
 end

--- a/app/models/fragrance.rb
+++ b/app/models/fragrance.rb
@@ -11,6 +11,10 @@ class Fragrance < ApplicationRecord
   has_one_attached :image
   has_many :calendars, dependent: :destroy
   has_one :review, dependent: :destroy
+  has_many :fragrance_tags, dependent: :destroy
+  has_many :tags, through: :fragrance_tags
+
+  validate :tags_count_within_limit
 
   # ransack用の検索設定
   def self.ransackable_attributes(auth_object = nil)
@@ -19,5 +23,14 @@ class Fragrance < ApplicationRecord
 
   def self.ransackable_associations(auth_object = nil)
     %w[reviews]
+  end
+
+  private
+
+  # タグの数を最大3つに制限
+  def tags_count_within_limit
+    if tags.size > 3
+      errors.add(:tags, 'は3つまでしか選択できません')
+    end
   end
 end

--- a/app/models/fragrance_tag.rb
+++ b/app/models/fragrance_tag.rb
@@ -1,2 +1,7 @@
 class FragranceTag < ApplicationRecord
+  belongs_to :fragrance
+  belongs_to :tag
+
+  # 同じ香水に同じタグが重複して付けられないようにする
+  validates :fragrance_id, uniqueness: { scope: :tag_id }
 end

--- a/app/models/fragrance_tag.rb
+++ b/app/models/fragrance_tag.rb
@@ -1,0 +1,2 @@
+class FragranceTag < ApplicationRecord
+end

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -1,0 +1,2 @@
+class Tag < ApplicationRecord
+end

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -1,2 +1,6 @@
 class Tag < ApplicationRecord
+  has_many :fragrance_tags, dependent: :destroy
+  has_many :fragrances, through: :fragrance_tags
+
+  validates :name, presence: true, uniqueness: true
 end

--- a/app/views/fragrances/_form.html.erb
+++ b/app/views/fragrances/_form.html.erb
@@ -36,6 +36,19 @@
             <%= form.label :image, class: "block font-bold mb-1" %>
             <%= form.file_field :image, class: "file-input file-input-bordered w-full" %>
           </div>
+
+          <div class="mb-4">
+            <%= form.label :tag_ids, "香りのカテゴリ（最大3つまで）", class: "block font-bold mb-1" %>
+            <div class="grid grid-cols-2 gap-2">
+              <%= form.collection_check_boxes :tag_ids, Tag.all, :id, :name do |b| %>
+                <div class="flex items-center">
+                  <%= b.check_box(class: "mr-2") %>
+                  <%= b.label(class: "text-sm") %>
+                </div>
+              <% end %>
+            </div>
+            <p class="text-sm text-gray-500 mt-1">※最大3つまで選択できます</p>
+          </div>
         </div>
 
         <!-- 右カラム：印象評価 -->
@@ -111,3 +124,27 @@
   </div>
 </section>
 
+<script>
+document.addEventListener('DOMContentLoaded', function() {
+  const checkboxes = document.querySelectorAll('input[name="fragrance[tag_ids][]"]');
+  const maxSelections = 3;
+
+  checkboxes.forEach(function(checkbox) {
+    checkbox.addEventListener('change', function() {
+      const checkedBoxes = document.querySelectorAll('input[name="fragrance[tag_ids][]"]:checked');
+
+      if (checkedBoxes.length >= maxSelections) {
+        checkboxes.forEach(function(cb) {
+          if (!cb.checked) {
+            cb.disabled = true;
+          }
+        });
+      } else {
+        checkboxes.forEach(function(cb) {
+          cb.disabled = false;
+        });
+      }
+    });
+  });
+});
+</script>

--- a/app/views/fragrances/_fragrance.html.erb
+++ b/app/views/fragrances/_fragrance.html.erb
@@ -16,6 +16,11 @@
   <div class="flex flex-grow flex-col px-3 mt-4">
     <p class="text-sm text-gray-500 font-semibold"><%= fragrance.brand %></p>
     <p class="text-xl font-bold"><%= fragrance.name %></p>
+
+    <!-- タグ -->
+    <div class="mt-2 mb-3">
+      <%= display_tags(fragrance) %>
+    </div>
   </div>
 
   <!-- 公開・非公開アイコン -->

--- a/app/views/fragrances/show.html.erb
+++ b/app/views/fragrances/show.html.erb
@@ -7,6 +7,12 @@
       <%= @fragrance.name %>
     </h1>
 
+    <!-- タグ -->
+    <div class="mb-4">
+      <span class="text-sm font-medium text-gray-700 mr-2">カテゴリ:</span>
+      <%= display_tags(@fragrance) %>
+    </div>
+
     <div class="md:flex md:space-x-6">
       <!-- 左側 -->
       <div class="md:w-1/2">

--- a/app/views/reviews/_review.html.erb
+++ b/app/views/reviews/_review.html.erb
@@ -17,6 +17,11 @@
   <div class="flex flex-grow flex-col px-3 mt-4">
     <p class="text-sm text-gray-500 font-semibold"><%= fragrance.brand %></p>
     <p class="text-xl font-bold"><%= fragrance.name %></p>
+
+    <!-- タグ -->
+    <div class="mt-2 mb-3">
+      <%= display_tags(review.fragrance) %>
+    </div>
   </div>
 
   <p class="line-clamp-3 text-sm text-gray-800 mb-2">

--- a/app/views/reviews/show.html.erb
+++ b/app/views/reviews/show.html.erb
@@ -7,6 +7,12 @@
       <%= @review.fragrance.name %>
     </h1>
 
+    <!-- タグ -->
+    <div class="mb-4">
+      <span class="text-sm font-medium text-gray-700 mr-2">カテゴリ:</span>
+      <%= display_tags(@review.fragrance) %>
+    </div>
+
     <div class="md:flex md:space-x-6">
       <!-- 左側 -->
       <div class="md:w-1/2">

--- a/bin/render-build.sh
+++ b/bin/render-build.sh
@@ -4,3 +4,4 @@ bundle install
 bundle exec rails assets:precompile
 bundle exec rails assets:clean
 bundle exec rails db:migrate
+bundle exec rails db:seed

--- a/db/migrate/20250821062930_create_tags.rb
+++ b/db/migrate/20250821062930_create_tags.rb
@@ -1,0 +1,11 @@
+class CreateTags < ActiveRecord::Migration[7.2]
+  def change
+    create_table :tags do |t|
+      t.string :name, null: false
+
+      t.timestamps
+    end
+
+    add_index :tags, :name, unique: true
+  end
+end

--- a/db/migrate/20250821062949_create_fragrance_tags.rb
+++ b/db/migrate/20250821062949_create_fragrance_tags.rb
@@ -1,0 +1,12 @@
+class CreateFragranceTags < ActiveRecord::Migration[7.2]
+  def change
+    create_table :fragrance_tags do |t|
+      t.references :fragrance, null: false, foreign_key: true
+      t.references :tag, null: false, foreign_key: true
+
+      t.timestamps
+    end
+
+    add_index :fragrance_tags, [:fragrance_id, :tag_id], unique: true
+  end
+end

--- a/db/migrate/20250821062949_create_fragrance_tags.rb
+++ b/db/migrate/20250821062949_create_fragrance_tags.rb
@@ -7,6 +7,6 @@ class CreateFragranceTags < ActiveRecord::Migration[7.2]
       t.timestamps
     end
 
-    add_index :fragrance_tags, [:fragrance_id, :tag_id], unique: true
+    add_index :fragrance_tags, [ :fragrance_id, :tag_id ], unique: true
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_08_14_050213) do
+ActiveRecord::Schema[7.2].define(version: 2025_08_21_062949) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -66,6 +66,16 @@ ActiveRecord::Schema[7.2].define(version: 2025_08_14_050213) do
     t.index ["user_id"], name: "index_comments_on_user_id"
   end
 
+  create_table "fragrance_tags", force: :cascade do |t|
+    t.bigint "fragrance_id", null: false
+    t.bigint "tag_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["fragrance_id", "tag_id"], name: "index_fragrance_tags_on_fragrance_id_and_tag_id", unique: true
+    t.index ["fragrance_id"], name: "index_fragrance_tags_on_fragrance_id"
+    t.index ["tag_id"], name: "index_fragrance_tags_on_tag_id"
+  end
+
   create_table "fragrances", force: :cascade do |t|
     t.string "name", null: false
     t.string "brand", null: false
@@ -93,6 +103,13 @@ ActiveRecord::Schema[7.2].define(version: 2025_08_14_050213) do
     t.index ["user_id"], name: "index_reviews_on_user_id"
   end
 
+  create_table "tags", force: :cascade do |t|
+    t.string "name", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["name"], name: "index_tags_on_name", unique: true
+  end
+
   create_table "users", force: :cascade do |t|
     t.string "email", default: "", null: false
     t.string "encrypted_password", default: "", null: false
@@ -112,6 +129,8 @@ ActiveRecord::Schema[7.2].define(version: 2025_08_14_050213) do
   add_foreign_key "calendars", "users"
   add_foreign_key "comments", "reviews"
   add_foreign_key "comments", "users"
+  add_foreign_key "fragrance_tags", "fragrances"
+  add_foreign_key "fragrance_tags", "tags"
   add_foreign_key "fragrances", "users"
   add_foreign_key "reviews", "fragrances"
   add_foreign_key "reviews", "users"

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -7,3 +7,13 @@
 #   ["Action", "Comedy", "Drama", "Horror"].each do |genre_name|
 #     MovieGenre.find_or_create_by!(name: genre_name)
 #   end
+
+#香水のタグ
+fragrance_categories = [
+  "フローラル", "シトラス", "フルーティ", "ウッディ",
+  "スパイシー", "オリエンタル", "マリン", "グリーン"
+]
+
+fragrance_categories.each do |category|
+  Tag.find_or_create_by(name: category)
+end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -8,7 +8,7 @@
 #     MovieGenre.find_or_create_by!(name: genre_name)
 #   end
 
-#香水のタグ
+# 香水のタグ
 puts "タグデータを作成中..."
 
 fragrance_categories = [

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -9,6 +9,8 @@
 #   end
 
 #香水のタグ
+puts "タグデータを作成中..."
+
 fragrance_categories = [
   "フローラル", "シトラス", "フルーティ", "ウッディ",
   "スパイシー", "オリエンタル", "マリン", "グリーン"
@@ -17,3 +19,5 @@ fragrance_categories = [
 fragrance_categories.each do |category|
   Tag.find_or_create_by(name: category)
 end
+
+puts "タグデータ作成完了: #{Tag.count}件"

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -17,7 +17,8 @@ fragrance_categories = [
 ]
 
 fragrance_categories.each do |category|
-  Tag.find_or_create_by(name: category)
+  tag = Tag.find_or_create_by(name: category)
+  puts "  ✓ #{category}" if tag.persisted?
 end
 
 puts "タグデータ作成完了: #{Tag.count}件"

--- a/test/fixtures/fragrance_tags.yml
+++ b/test/fixtures/fragrance_tags.yml
@@ -4,8 +4,3 @@
 # model remove the "{}" from the fixture names and add the columns immediately
 # below each fixture, per the syntax in the comments below
 #
-one: {}
-# column: value
-#
-two: {}
-# column: value

--- a/test/fixtures/fragrance_tags.yml
+++ b/test/fixtures/fragrance_tags.yml
@@ -1,0 +1,11 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+# This model initially had no columns defined. If you add columns to the
+# model remove the "{}" from the fixture names and add the columns immediately
+# below each fixture, per the syntax in the comments below
+#
+one: {}
+# column: value
+#
+two: {}
+# column: value

--- a/test/fixtures/tags.yml
+++ b/test/fixtures/tags.yml
@@ -4,8 +4,3 @@
 # model remove the "{}" from the fixture names and add the columns immediately
 # below each fixture, per the syntax in the comments below
 #
-one: {}
-# column: value
-#
-two: {}
-# column: value

--- a/test/fixtures/tags.yml
+++ b/test/fixtures/tags.yml
@@ -1,0 +1,11 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+# This model initially had no columns defined. If you add columns to the
+# model remove the "{}" from the fixture names and add the columns immediately
+# below each fixture, per the syntax in the comments below
+#
+one: {}
+# column: value
+#
+two: {}
+# column: value

--- a/test/models/fragrance_tag_test.rb
+++ b/test/models/fragrance_tag_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class FragranceTagTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/test/models/tag_test.rb
+++ b/test/models/tag_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class TagTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
# 概要
香水の香りの種類(フローラル、シトラスなど)をタグとしてつけられるように

# 実施した内容
- tagモデルとfragrance_tagモデル作成
- モデルのバリデーションとアソシエーション記述してdb:migrate
- db/seeds.rbで香りのカテゴリを登録(フローラル、シトラス、フルーティ、ウッディ、スパイシー、オリエンタル、マリン、グリーン)
- bin/render-build.shでデプロイ時にdb:seedを行うように変更
- マイ香水登録フォームに香りカテゴリの選択チェックボックスを追加（複数選択あり、最大３つ）
- マイ香水・みんなの香水の一覧・詳細にカテゴリを表示
- タグがない場合はカテゴリ未選択と表示

# 補足
タグ検索はまだ

# 関連issue
#86 