### PR TITLE
Feature/#99 タグ検索機能

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -16,4 +16,17 @@ module ApplicationHelper
       content_tag :span, tag.name, class: "inline-block bg-accent text-xs px-2 py-1 rounded-full mr-1 mb-1"
     end.join.html_safe
   end
+
+  # タグ表示部分
+  def display_tags(fragrance, context: :review)
+    return content_tag(:span, "カテゴリ未設定", class: "text-gray-500 text-sm") if fragrance.tags.empty?
+
+    fragrance.tags.map do |tag|
+      link_to reviews_path(q: { fragrance_tags_id_eq: tag.id }),
+              class: "inline-block bg-accent hover:bg-accent-focus text-xs px-2 py-1 rounded-full mr-1 mb-1 transition-colors",
+              title: "「#{tag.name}」で絞り込み" do
+        tag.name
+      end
+    end.join(" ").html_safe
+  end
 end

--- a/app/models/fragrance.rb
+++ b/app/models/fragrance.rb
@@ -22,7 +22,7 @@ class Fragrance < ApplicationRecord
   end
 
   def self.ransackable_associations(auth_object = nil)
-    %w[reviews]
+    %w[review tags user fragrance_tags]
   end
 
   private

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -3,4 +3,13 @@ class Tag < ApplicationRecord
   has_many :fragrances, through: :fragrance_tags
 
   validates :name, presence: true, uniqueness: true
+
+    # ransack用の検索設定
+    def self.ransackable_attributes(auth_object = nil)
+      %w[name id]
+    end
+
+    def self.ransackable_associations(auth_object = nil)
+      %w[fragrances fragrance_tags]
+    end
 end

--- a/app/views/reviews/_search_form.html.erb
+++ b/app/views/reviews/_search_form.html.erb
@@ -13,7 +13,7 @@
           <!-- タグ検索ドロップダウン -->
           <%= f.collection_select :tags_id_eq,
               Tag.all, :id, :name,
-              { prompt: "タグを選択してください" },
+              { prompt: "香りのカテゴリを選択" },
               { class: "form-control" } %>
 
           <!-- 検索ボタン -->

--- a/app/views/reviews/_search_form.html.erb
+++ b/app/views/reviews/_search_form.html.erb
@@ -1,53 +1,76 @@
 <div class="flex justify-center px-4 sm:px-6 md:px-8 mt-6">
   <div class="w-full max-w-5xl space-y-4 p-6 bg-white backdrop-blur-md rounded-lg shadow-lg mb-4">
 
-    <%= search_form_for q, url: reviews_path, method: :get, class: "space-y-4", local: true do |f| %>
-      <div class="form-control">
-        <!-- 香水名・ブランド名検索 -->
-        <%= f.label :fragrance_name_or_fragrance_brand_cont, "香水名・ブランド名", class: "label" %>
-        <div class="flex gap-2">
-          <%= f.search_field :fragrance_name_or_fragrance_brand_cont,
-              class: "input input-bordered flex-1 w-full p-3 border border-gray-300 rounded-xl shadow-sm",
-              placeholder: "検索ワードを入力" %>
+    <%= search_form_for q, url: reviews_path, method: :get, class: "mb-6", local: true do |f| %>
+      <div class="space-y-4">
+        <!-- 香水名・ブランド名検索（上段） -->
+        <div class="form-control">
+          <%= f.label :fragrance_name_or_fragrance_brand_cont, "香水名・ブランド名", class: "label font-semibold text-gray-700" %>
+          <div class="flex gap-2">
+            <%= f.search_field :fragrance_name_or_fragrance_brand_cont,
+              class: "input input-bordered flex-1",
+              placeholder: "例：シャネル、ディオール" %>
 
-          <!-- タグ検索ドロップダウン -->
-          <%= f.collection_select :tags_id_eq,
+            <!-- 検索ボタン -->
+            <button type="submit" class="btn btn-primary">
+              <i class="fas fa-search mr-1"></i>
+              検索
+            </button>
+          </div>
+        </div>
+
+        <!--（下段） -->
+        <div class="grid grid-cols-1 md:grid-cols-3 gap-4">
+          <!-- タグ検索 -->
+          <div class="form-control">
+            <%= f.label :fragrance_tags_id_eq, "香りのカテゴリ", class: "label font-semibold text-gray-700" %>
+            <%= f.collection_select :fragrance_tags_id_eq,
               Tag.all, :id, :name,
-              { prompt: "香りのカテゴリを選択" },
-              { class: "form-control" } %>
-
-          <!-- 検索ボタン -->
-          <button type="submit" class="btn btn-primary">
-            <i class="fas fa-search"></i>
-            検索
-          </button>
+                { prompt: "カテゴリを選択" },
+                { class: "select select-bordered w-full" } %>
+          </div>
         </div>
       </div>
     <% end %>
 
-    <!-- 検索状態の表示エリア -->
+    <!-- 検索状態の表示 -->
     <% if params[:q].present? %>
-      <div class="flex flex-col sm:flex-row sm:justify-between sm:items-center gap-2">
-        <!-- 検索結果の件数表示 -->
-        <div class="alert alert-info flex-1">
-          <i class="fa-solid fa-info-circle"></i>
-          <span>
-            検索結果: <strong><%= @reviews.total_count %></strong>件
-            <% if params[:q][:fragrance_name_or_fragrance_brand_cont].present? %>
-              （「<strong><%= params[:q][:fragrance_name_or_fragrance_brand_cont] %></strong>」を含む）
-            <% end %>
-          </span>
-        </div>
+      <div class="bg-base-200 p-4 rounded-lg mb-4">
+        <div class="flex flex-col sm:flex-row sm:justify-between sm:items-start gap-3">
+          <!-- 検索結果の件数 -->
+          <div class="flex items-center gap-2">
+            <i class="fa-solid fa-search text-primary"></i>
+            <span class="font-semibold">
+              検索結果: <span class="text-primary text-lg"><%= @reviews.total_count %></span>件
+            </span>
+          </div>
 
-        <!-- 検索条件をクリアするボタン -->
-        <div>
-          <%= link_to reviews_path, class: "btn btn-outline btn-sm" do %>
-            <i class="fas fa-times mr-1"></i>
-            検索条件をクリア
-          <% end %>
+          <!-- 検索条件をバッジで表示 -->
+          <div class="flex flex-wrap gap-2">
+            <!-- 香水名・ブランド名 -->
+            <% if params[:q][:fragrance_name_or_fragrance_brand_cont].present? %>
+              <div class="badge badge-primary gap-1">
+                <i class="fas fa-tag"></i>
+                キーワード: <%= params[:q][:fragrance_name_or_fragrance_brand_cont] %>
+              </div>
+            <% end %>
+
+            <!-- タグ検索 -->
+            <% if params[:q][:fragrance_tags_id_eq].present? %>
+              <div class="badge badge-secondary gap-1">
+                <i class="fas fa-bookmark"></i>
+                <%= Tag.find(params[:q][:fragrance_tags_id_eq]).name %>
+              </div>
+            <% end %>
+
+            <!-- クリアボタン -->
+            <%= link_to reviews_path, class: "btn btn-outline btn-sm" do %>
+              <i class="fas fa-times"></i>
+              検索条件をクリア
+            <% end %>
+          </div>
         </div>
       </div>
     <% end %>
-
   </div>
 </div>

--- a/app/views/reviews/_search_form.html.erb
+++ b/app/views/reviews/_search_form.html.erb
@@ -3,12 +3,20 @@
 
     <%= search_form_for q, url: reviews_path, method: :get, class: "space-y-4", local: true do |f| %>
       <div class="form-control">
+        <!-- 香水名・ブランド名検索 -->
         <%= f.label :fragrance_name_or_fragrance_brand_cont, "香水名・ブランド名", class: "label" %>
         <div class="flex gap-2">
           <%= f.search_field :fragrance_name_or_fragrance_brand_cont,
               class: "input input-bordered flex-1 w-full p-3 border border-gray-300 rounded-xl shadow-sm",
               placeholder: "検索ワードを入力" %>
-          <!-- 検索ボタンを横並びに -->
+
+          <!-- タグ検索ドロップダウン -->
+          <%= f.collection_select :tags_id_eq,
+              Tag.all, :id, :name,
+              { prompt: "タグを選択してください" },
+              { class: "form-control" } %>
+
+          <!-- 検索ボタン -->
           <button type="submit" class="btn btn-primary">
             <i class="fas fa-search"></i>
             検索


### PR DESCRIPTION
# 概要
香りのカテゴリタグでもレビューを検索可能に

# 実施した内容
- _search_form.html.erbを編集し、香りのカテゴリ検索用のドロップダウンを追加
- モデルにransackで検索可能なカラムを追記
- 既に実装済みのブランド名or香水名検索とはandになるように
- 検索結果画面で、なんの条件で検索したかをバッジ形式で表示
- 一覧や詳細画面に表示されたタグをクリックしても検索できるようdisplay_tagsメソッドを編集

# 補足
香水診断の結果からタグ検索のレビュー一覧に飛ぶ機能は別issue立てる

# 関連issue
#99 
