### PR TITLE
Feature/#100 お気に入り機能

### DIFF
--- a/app/controllers/favorites_controller.rb
+++ b/app/controllers/favorites_controller.rb
@@ -1,0 +1,3 @@
+class FavoritesController < ApplicationController
+  
+end

--- a/app/controllers/favorites_controller.rb
+++ b/app/controllers/favorites_controller.rb
@@ -12,9 +12,9 @@ class FavoritesController < ApplicationController
   end
 
   def destroy
-    @favorite = current_user.favorites.find(params[:id])
-    @review = @favorite.review
-    @favorite.destroy
+    @review = Review.find(params[:review_id])
+    @favorite = current_user.favorites.find_by(review: @review)
+    @favorite&.destroy
 
     respond_to do |format|
       format.turbo_stream

--- a/app/controllers/favorites_controller.rb
+++ b/app/controllers/favorites_controller.rb
@@ -1,3 +1,24 @@
 class FavoritesController < ApplicationController
-  
+  def create
+    @review = Review.find(params[:review_id])
+    @favorite = current_user.favorites.build(review: @review)
+
+    if @favorite.save
+      respond_to do |format|
+        format.turbo_stream
+        format.html { redirect_to review_path(@review) }
+      end
+    end
+  end
+
+  def destroy
+    @favorite = current_user.favorites.find(params[:id])
+    @review = @favorite.review
+    @favorite.destroy
+
+    respond_to do |format|
+      format.turbo_stream
+      format.html { redirect_to review_path(@review) }
+    end
+  end
 end

--- a/app/controllers/profiles_controller.rb
+++ b/app/controllers/profiles_controller.rb
@@ -2,6 +2,8 @@ class ProfilesController < ApplicationController
   before_action :set_user, only: [ :show, :edit, :update ]
 
   def show
+    # プロフィールページでは最新のお気に入り数件を表示
+    @recent_favorites = current_user.favorite_reviews.includes(:fragrance, :user).limit(4).order(created_at: :desc)
   end
 
   def edit
@@ -14,6 +16,11 @@ class ProfilesController < ApplicationController
       flash.now[:alert] = t("defaults.flash_message.not_updated", item: User.model_name.human)
       render :edit, status: :unprocessable_entity
     end
+  end
+
+  def favorites
+    # お気に入り一覧の全件表示
+    @favorite_reviews = current_user.favorite_reviews.includes(:fragrance, :user).order(created_at: :desc)
   end
 
   private

--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -26,7 +26,7 @@ class Users::SessionsController < Devise::SessionsController
   # end
 
   def after_sign_in_path_for(resource)
-    calendars_path
+    reviews_path
   end
 
   def after_sign_out_path_for(resource_or_scope)

--- a/app/helpers/favorites_helper.rb
+++ b/app/helpers/favorites_helper.rb
@@ -1,0 +1,2 @@
+module FavoriteHelper
+end

--- a/app/helpers/favorites_helper.rb
+++ b/app/helpers/favorites_helper.rb
@@ -1,2 +1,2 @@
-module FavoriteHelper
+module FavoritesHelper
 end

--- a/app/models/favorite.rb
+++ b/app/models/favorite.rb
@@ -1,0 +1,2 @@
+class Favorite < ApplicationRecord
+end

--- a/app/models/favorite.rb
+++ b/app/models/favorite.rb
@@ -1,2 +1,7 @@
 class Favorite < ApplicationRecord
+  belongs_to :user
+  belongs_to :review
+
+  # 同じユーザーが同じレビューを複数回お気に入りできないように
+  validates :user_id, uniqueness: { scope: :review_id }
 end

--- a/app/models/review.rb
+++ b/app/models/review.rb
@@ -3,6 +3,8 @@ class Review < ApplicationRecord
   belongs_to :fragrance
 
   has_many :comments, dependent: :destroy
+  has_many :favorites, dependent: :destroy
+  has_many :favorited_users, through: :favorites, source: :user
 
   validates :body, presence: true, length: { maximum: 1000 }
   validates :fragrance_id, uniqueness: { scope: :user_id, message: "はすでにレビュー済みです" }

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -8,6 +8,8 @@ class User < ApplicationRecord
   has_many :calendars, dependent: :destroy
   has_many :reviews, dependent: :destroy
   has_many :comments, dependent: :destroy
+  has_many :favorites, dependent: :destroy
+  has_many :favorite_reviews, through: :favorites, source: :review
 
   has_one_attached :profile_image
 

--- a/app/views/favorites/create.turbo_stream.erb
+++ b/app/views/favorites/create.turbo_stream.erb
@@ -1,0 +1,3 @@
+<%= turbo_stream.replace "favorite-button-#{@review.id}" do %>
+  <%= render 'shared/favorite_button', review: @review %>
+<% end %>

--- a/app/views/favorites/destroy.turbo_stream.erb
+++ b/app/views/favorites/destroy.turbo_stream.erb
@@ -1,0 +1,3 @@
+<%= turbo_stream.replace "favorite-button-#{@review.id}" do %>
+  <%= render 'shared/favorite_button', review: @review %>
+<% end %>

--- a/app/views/profiles/_favorite_review.html.erb
+++ b/app/views/profiles/_favorite_review.html.erb
@@ -1,0 +1,63 @@
+<div class="bg-white from-pink-50 to-purple-50 backdrop-blur-m p-4 rounded-xl shadow-lg flex flex-col relative">
+  <!-- お気に入り追加日を表示 -->
+  <div class="absolute top-2 right-2 bg-pink-200 text-pink-700 text-xs px-2 py-1 rounded-full">
+    <i class="fa-solid fa-star mr-1"></i>
+    <%= time_ago_in_words(current_user.favorites.find_by(review: review).created_at) %>前
+  </div>
+
+  <% fragrance = review.fragrance %>
+  <!-- ボトル画像 -->
+  <div class="h-48 flex items-center justify-center rounded-md overflow-hidden">
+    <%= link_to review_path(review), data: { action: "click->loading#show" } do %>
+      <div class="object-cover w-full h-[160px] cursor-pointer transition hover:opacity-80">
+        <% if fragrance.image.attached? %>
+          <%= image_tag fragrance.image.variant(resize_to_limit: [400, 300]), class: "w-full h-full object-cover rounded-xl shadow" %>
+        <% else %>
+          <%= image_tag "default_fragrance.png", class: "w-full h-full object-cover rounded-xl shadow" %>
+        <% end %>
+      </div>
+    <% end %>
+  </div>
+
+  <!-- ブランド名・香水名 -->
+  <div class="flex flex-grow flex-col px-3 mt-4">
+    <p class="text-sm text-gray-600 font-semibold"><%= fragrance.brand %></p>
+    <p class="text-lg font-bold text-gray-800"><%= fragrance.name %></p>
+
+    <!-- タグ -->
+    <div class="mt-2 mb-3">
+      <%= display_tags(review.fragrance) %>
+    </div>
+  </div>
+
+  <!-- レビュー内容 -->
+  <p class="line-clamp-2 text-sm text-gray-700 mb-3">
+    <%= simple_format(truncate(review.body, length: 80, omission: '…')) %>
+  </p>
+
+  <!-- ユーザー情報 -->
+  <div class="flex items-center justify-between text-sm text-gray-600">
+    <div class="flex items-center">
+      <div class="avatar mr-2">
+        <div class="w-6 rounded-full">
+          <% if review.user.profile_image.attached? %>
+            <%= image_tag review.user.profile_image, alt: review.user.name %>
+          <% else %>
+            <div class="bg-neutral text-neutral-content rounded-full w-6 h-6 flex items-center justify-center">
+              <i class="fa-solid fa-user text-xs"></i>
+            </div>
+          <% end %>
+        </div>
+      </div>
+      <span><%= review.user.name.presence || "匿名" %></span>
+    </div>
+
+    <!-- お気に入りボタン（解除ボタンとして機能） -->
+    <div class="flex items-center space-x-2">
+      <%= link_to review_path(review), class: "btn btn-xs btn-outline btn-primary" do %>
+      詳細
+      <% end %>
+      <%= render 'shared/favorite_button', review: review %>
+    </div>
+  </div>
+</div>

--- a/app/views/profiles/favorites.html.erb
+++ b/app/views/profiles/favorites.html.erb
@@ -1,0 +1,67 @@
+<% content_for(:title, "お気に入り一覧") %>
+
+<section class="px-4 py-12 sm:px-6 lg:px-8">
+  <div class="max-w-6xl mx-auto mb-8">
+    <!-- 戻るボタン -->
+    <div class="mb-6">
+      <%= link_to profile_path, class: "btn btn-ghost btn-sm text-gray-600 hover:text-gray-800" do %>
+        <i class="fa-solid fa-arrow-left mr-2"></i>
+        プロフィールに戻る
+      <% end %>
+    </div>
+
+    <!-- ページタイトル -->
+    <div class="text-center mb-8">
+      <h1 class="text-3xl font-bold text-gray-800 mb-2">
+        <i class="fa-solid fa-star mr-3"></i>
+        お気に入り一覧
+      </h1>
+      <p class="text-gray-600">
+        あなたがお気に入りに追加した香水のレビュー
+      </p>
+      <% if @favorite_reviews.present? %>
+        <p class="text-sm text-gray-500 mt-2">
+          全<span class="font-semibold text-pink-600"><%= @favorite_reviews.count %></span>件のレビュー
+        </p>
+      <% end %>
+    </div>
+  </div>
+
+  <!-- お気に入りレビュー一覧 -->
+  <div class="max-w-6xl mx-auto mt-4">
+    <% if @favorite_reviews.present? %>
+      <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+        <% @favorite_reviews.each do |review| %>
+          <%= render 'profiles/favorite_review',
+              review: review,
+              show_favorite_date: true,
+              compact_mode: false %>
+        <% end %>
+      </div>
+    <% else %>
+      <!-- 空の状態 -->
+      <div class="text-center py-16">
+        <div class="mb-6">
+          <i class="fa-solid fa-heart-crack text-gray-300 text-8xl mb-4"></i>
+        </div>
+        <h3 class="text-xl font-semibold text-gray-600 mb-3">
+          まだお気に入りのレビューがありません
+        </h3>
+        <p class="text-gray-500 mb-6 max-w-md mx-auto">
+          気になる香りのレビューを見つけて、<br>
+          お気に入りに追加してみましょう！
+        </p>
+        <div class="space-y-3">
+          <%= link_to reviews_path, class: "btn btn-primary mr-3" do %>
+            <i class="fa-solid fa-search mr-2"></i>
+            レビューを探す
+          <% end %>
+          <%= link_to profile_path, class: "btn btn-outline btn-secondary" do %>
+            <i class="fa-solid fa-user mr-2"></i>
+            プロフィールに戻る
+          <% end %>
+        </div>
+      </div>
+    <% end %>
+  </div>
+</section>

--- a/app/views/profiles/show.html.erb
+++ b/app/views/profiles/show.html.erb
@@ -48,4 +48,39 @@
       <% end %>
     </div>
   </div>
+
+  <!-- お気に入りレビュー -->
+  <div class="max-w-4xl w-full mx-auto mt-4">
+    <div class="bg-base rounded-xl shadow-lg p-6">
+      <div class="flex items-center justify-between mb-6">
+        <h2 class="text-2xl font-bold text-gray-800 flex items-center">
+          <i class="fa-solid fa-star mr-2"></i>
+          お気に入りレビュー
+        </h2>
+        <% if @recent_favorites.present? %>
+          <%= link_to profile_favorites_path, class: "btn btn-outline btn-sm" do %>
+            <i class="fa-solid fa-arrow-right"></i>
+            すべて見る
+          <% end %>
+        <% end %>
+      </div>
+
+      <% if @recent_favorites.present? %>
+        <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+          <% @recent_favorites.each do |review| %>
+            <%= render 'profiles/favorite_review', review: review %>
+          <% end %>
+        </div>
+      <% else %>
+        <div class="text-center py-12">
+          <i class="fa-solid fa-heart-crack text-gray-300 text-6xl mb-4"></i>
+          <p class="text-gray-500 mb-4">まだお気に入りのレビューがありません</p>
+          <%= link_to reviews_path, class: "btn btn-primary" do %>
+            <i class="fa-solid fa-search mr-2"></i>
+            レビューを探す
+          <% end %>
+        </div>
+      <% end %>
+    </div>
+  </div>
 </section>

--- a/app/views/reviews/_review.html.erb
+++ b/app/views/reviews/_review.html.erb
@@ -29,18 +29,25 @@
   </p>
 
   <!-- ユーザー情報 -->
-  <div class="flex items-center text-sm text-gray-600 mb-2">
-    <div class="avatar mr-2">
-      <div class="w-6 rounded-full">
-        <% if review.user.profile_image.attached? %>
-          <%= image_tag review.user.profile_image, alt: review.user.name %>
-        <% else %>
-          <div class="bg-neutral text-neutral-content rounded-full w-6 h-6 flex items-center justify-center">
-            <i class="fa-solid fa-user text-xs"></i>
-          </div>
-        <% end %>
+  <div class="flex items-center justify-between text-sm text-gray-600 mb-2">
+    <div class="flex items-center">
+      <div class="avatar mr-2">
+        <div class="w-6 rounded-full">
+          <% if review.user.profile_image.attached? %>
+            <%= image_tag review.user.profile_image, alt: review.user.name %>
+          <% else %>
+            <div class="bg-neutral text-neutral-content rounded-full w-6 h-6 flex items-center justify-center">
+              <i class="fa-solid fa-user text-xs"></i>
+            </div>
+          <% end %>
+        </div>
       </div>
+      <span><%= review.user.name.presence || "匿名" %></span>
     </div>
-    <span><%= review.user.name.presence || "匿名" %></span>
+
+    <!-- お気に入りボタン -->
+    <div class="ml-auto">
+      <%= render 'shared/favorite_button', review: review %>
+    </div>
   </div>
 </div>

--- a/app/views/reviews/show.html.erb
+++ b/app/views/reviews/show.html.erb
@@ -2,15 +2,24 @@
 
 <section class="px-4 py-10 sm:px-6 lg:px-8">
   <div class="max-w-4xl mx-auto bg-white p-6 rounded-xl shadow-lg">
-    <h1 class="text-2xl font-bold">
-      <span class="text-base text-gray-500 mr-2"><%= @review.fragrance.brand %></span>
-      <%= @review.fragrance.name %>
-    </h1>
+    <div class="absolute top-4 right-4 z-10">
+      <%= render 'shared/favorite_button', review: @review,
+                  class: "bg-white/80 backdrop-blur-sm rounded-full p-2 shadow-md hover:bg-white/90 transition-all" %>
+    </div>
 
-    <!-- タグ -->
-    <div class="mb-4">
-      <span class="text-sm font-medium text-gray-700 mr-2">カテゴリ:</span>
-      <%= display_tags(@review.fragrance) %>
+    <div class="flex items-start justify-between mb-4">
+      <div class="flex-1">
+        <h1 class="text-2xl font-bold">
+          <span class="text-base text-gray-500 mr-2"><%= @review.fragrance.brand %></span>
+          <%= @review.fragrance.name %>
+        </h1>
+
+        <!-- タグ -->
+        <div class="mt-2">
+          <span class="text-sm font-medium text-gray-700 mr-2">カテゴリ:</span>
+          <%= display_tags(@review.fragrance) %>
+        </div>
+      </div>
     </div>
 
     <div class="md:flex md:space-x-6">

--- a/app/views/shared/_favorite_button.html.erb
+++ b/app/views/shared/_favorite_button.html.erb
@@ -2,22 +2,20 @@
   <% if user_signed_in? %>
     <% if current_user.favorites.exists?(review: review) %>
       <!-- お気に入り済み -->
-      <%= link_to review_favorites_path(review),
-                  method: :delete,
+      <%= link_to review_favorite_path(review),
                   data: { turbo_method: :delete },
                   class: "favorite-btn favorited",
                   title: "お気に入りを解除" do %>
-        <i class="fas fa-star text-warning"></i> <!-- 黄色の塗りつぶし星 -->
+        <i class="fas fa-star text-warning"></i>
         <span class="favorite-count"><%= review.favorites.count %></span>
       <% end %>
     <% else %>
       <!-- 未お気に入り -->
-      <%= link_to review_favorites_path(review),
-                  method: :post,
+      <%= link_to review_favorite_path(review),
                   data: { turbo_method: :post },
                   class: "favorite-btn",
                   title: "お気に入りに追加" do %>
-        <i class="far fa-star text-muted"></i> <!-- グレーの中空星 -->
+        <i class="far fa-star text-muted"></i>
         <span class="favorite-count"><%= review.favorites.count %></span>
       <% end %>
     <% end %>

--- a/app/views/shared/_favorite_button.html.erb
+++ b/app/views/shared/_favorite_button.html.erb
@@ -1,0 +1,31 @@
+<div id="favorite-button-<%= review.id %>" class="favorite-button-container">
+  <% if user_signed_in? %>
+    <% if current_user.favorites.exists?(review: review) %>
+      <!-- お気に入り済み -->
+      <%= link_to review_favorites_path(review),
+                  method: :delete,
+                  data: { turbo_method: :delete },
+                  class: "favorite-btn favorited",
+                  title: "お気に入りを解除" do %>
+        <i class="fas fa-star text-warning"></i> <!-- 黄色の塗りつぶし星 -->
+        <span class="favorite-count"><%= review.favorites.count %></span>
+      <% end %>
+    <% else %>
+      <!-- 未お気に入り -->
+      <%= link_to review_favorites_path(review),
+                  method: :post,
+                  data: { turbo_method: :post },
+                  class: "favorite-btn",
+                  title: "お気に入りに追加" do %>
+        <i class="far fa-star text-muted"></i> <!-- グレーの中空星 -->
+        <span class="favorite-count"><%= review.favorites.count %></span>
+      <% end %>
+    <% end %>
+  <% else %>
+    <!-- 未ログイン時：お気に入り数のみ表示 -->
+    <span class="favorite-display">
+      <i class="far fa-star text-muted"></i>
+      <span class="favorite-count"><%= review.favorites.count %></span>
+    </span>
+  <% end %>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -14,12 +14,8 @@ Rails.application.routes.draw do
     get :result
   end
 
-  # プロフィールページ（お気に入り一覧も表示）
-  resource :profile, only: %i[show edit update] do
-    collection do
-      get :favorites
-    end
-  end
+  resource :profile, only: %i[show edit update]
+  get "profile/favorites", to: "profiles#favorites", as: "profile_favorites"
 
   get "/health", to: "application#health"
   # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,7 +7,7 @@ Rails.application.routes.draw do
   resources :fragrances
   resources :calendars
   resources :reviews do
-    resources :favorites, only: %i[create destroy]
+    resource :favorite, only: %i[create destroy]
     resources :comments, only: %i[create destroy edit update], shallow: true
   end
   resource :diagnosis, only: %i[new create ] do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,13 +7,19 @@ Rails.application.routes.draw do
   resources :fragrances
   resources :calendars
   resources :reviews do
+    resources :favorites, only: %i[create destroy]
     resources :comments, only: %i[create destroy edit update], shallow: true
   end
-  resource :diagnosis, only: [ :new, :create ] do
+  resource :diagnosis, only: %i[new create ] do
     get :result
   end
 
-  resource :profile, only: %i[show edit update]
+  # プロフィールページ（お気に入り一覧も表示）
+  resource :profile, only: %i[show edit update] do
+    collection do
+      get :favorites
+    end
+  end
 
   get "/health", to: "application#health"
   # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html

--- a/db/migrate/20250822021610_create_favorites.rb
+++ b/db/migrate/20250822021610_create_favorites.rb
@@ -1,7 +1,13 @@
 class CreateFavorites < ActiveRecord::Migration[7.2]
   def change
     create_table :favorites do |t|
+      t.references :user, null: false, foreign_key: true
+      t.references :review, null: false, foreign_key: true
+
       t.timestamps
     end
+
+    # 同じユーザーが同じレビューを複数回お気に入りできないように
+    add_index :favorites, [ :user_id, :review_id ], unique: true
   end
 end

--- a/db/migrate/20250822021610_create_favorites.rb
+++ b/db/migrate/20250822021610_create_favorites.rb
@@ -1,0 +1,7 @@
+class CreateFavorites < ActiveRecord::Migration[7.2]
+  def change
+    create_table :favorites do |t|
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_08_21_062949) do
+ActiveRecord::Schema[7.2].define(version: 2025_08_22_021610) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -64,6 +64,16 @@ ActiveRecord::Schema[7.2].define(version: 2025_08_21_062949) do
     t.datetime "updated_at", null: false
     t.index ["review_id"], name: "index_comments_on_review_id"
     t.index ["user_id"], name: "index_comments_on_user_id"
+  end
+
+  create_table "favorites", force: :cascade do |t|
+    t.bigint "user_id", null: false
+    t.bigint "review_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["review_id"], name: "index_favorites_on_review_id"
+    t.index ["user_id", "review_id"], name: "index_favorites_on_user_id_and_review_id", unique: true
+    t.index ["user_id"], name: "index_favorites_on_user_id"
   end
 
   create_table "fragrance_tags", force: :cascade do |t|
@@ -129,6 +139,8 @@ ActiveRecord::Schema[7.2].define(version: 2025_08_21_062949) do
   add_foreign_key "calendars", "users"
   add_foreign_key "comments", "reviews"
   add_foreign_key "comments", "users"
+  add_foreign_key "favorites", "reviews"
+  add_foreign_key "favorites", "users"
   add_foreign_key "fragrance_tags", "fragrances"
   add_foreign_key "fragrance_tags", "tags"
   add_foreign_key "fragrances", "users"

--- a/test/controllers/favorites_controller_test.rb
+++ b/test/controllers/favorites_controller_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class FavoritesControllerTest < ActionDispatch::IntegrationTest
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/test/fixtures/favorites.yml
+++ b/test/fixtures/favorites.yml
@@ -1,0 +1,11 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+# This model initially had no columns defined. If you add columns to the
+# model remove the "{}" from the fixture names and add the columns immediately
+# below each fixture, per the syntax in the comments below
+#
+one: {}
+# column: value
+#
+two: {}
+# column: value

--- a/test/fixtures/favorites.yml
+++ b/test/fixtures/favorites.yml
@@ -4,8 +4,4 @@
 # model remove the "{}" from the fixture names and add the columns immediately
 # below each fixture, per the syntax in the comments below
 #
-one: {}
-# column: value
-#
-two: {}
-# column: value
+

--- a/test/models/favorite_test.rb
+++ b/test/models/favorite_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class FavoriteTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
# 概要
レビューの中からお気に入りに登録できるように。お気に入りしたもの一覧はプロフィールページに表示

# 実施した内容
- favoriteモデルを作成しバリデーションとアソシエーション設定
- ルーティングにcreate,destroy,favorites追加
- profileコントローラーにfavoritesアクション追加しお気に入り一覧を表示
- favoriteコントローラー作成しupdateとdesrotyアクション記述
- _favorite_button.html.erbでお気に入りボタンのビュー作成
- みんなの香水一覧・詳細ページにお気に入り（⭐️）ボタンを設置
- お気に入りした香水はプロフィールページに最新４件のみ表示→全て見るで一覧ページ（_favorites.html.erb）へ
- favorites/create.turbo_stream.erbとdestroy.turbo_stream.erbを作成し、お気に入りと解除は非同期でできるように

# 補足

# 関連issue
#100 
