### PR TITLE
style:お気に入りボタンのアイコンを星からハートに変更

### DIFF
--- a/app/views/profiles/_favorite_review.html.erb
+++ b/app/views/profiles/_favorite_review.html.erb
@@ -1,7 +1,7 @@
 <div class="bg-white from-pink-50 to-purple-50 backdrop-blur-m p-4 rounded-xl shadow-lg flex flex-col relative">
   <!-- お気に入り追加日を表示 -->
   <div class="absolute top-2 right-2 bg-base text-base-content text-xs px-2 py-1 rounded-full">
-    <i class="fa-solid fa-star mr-1"></i>
+    <i class="fas fa-heart mr-1"></i>
     <%= time_ago_in_words(current_user.favorites.find_by(review: review).created_at) %>前
   </div>
 

--- a/app/views/profiles/favorites.html.erb
+++ b/app/views/profiles/favorites.html.erb
@@ -13,11 +13,11 @@
     <!-- ページタイトル -->
     <div class="text-center mb-8">
       <h1 class="text-3xl font-bold text-gray-800 mb-2">
-        <i class="fa-solid fa-star mr-3"></i>
+        <i class="fas fa-heart" style="color: #fde484;" mr-2></i>
         お気に入り一覧
       </h1>
       <p class="text-gray-600">
-        あなたがお気に入りに追加した香水のレビュー
+        あなたがお気に入りに追加した香水
       </p>
       <% if @favorite_reviews.present? %>
         <p class="text-sm text-gray-500 mt-2">

--- a/app/views/profiles/show.html.erb
+++ b/app/views/profiles/show.html.erb
@@ -54,7 +54,7 @@
     <div class="bg-base rounded-xl shadow-lg p-6">
       <div class="flex items-center justify-between mb-6">
         <h2 class="text-2xl font-bold text-gray-800 flex items-center">
-          <i class="fa-solid fa-star mr-2"></i>
+          <i class="fas fa-heart" style="color: #fde484;" mr-2></i>
           お気に入りレビュー
         </h2>
         <% if @recent_favorites.present? %>

--- a/app/views/shared/_favorite_button.html.erb
+++ b/app/views/shared/_favorite_button.html.erb
@@ -6,7 +6,7 @@
                   data: { turbo_method: :delete },
                   class: "favorite-btn favorited",
                   title: "お気に入りを解除" do %>
-        <i class="fas fa-star" style="color: #fde484;"></i>
+        <i class="fas fa-heart" style="color: #fde484;"></i>
         <span class="favorite-count"><%= review.favorites.count %></span>
       <% end %>
     <% else %>
@@ -15,7 +15,7 @@
                   data: { turbo_method: :post },
                   class: "favorite-btn",
                   title: "お気に入りに追加" do %>
-        <i class="far fa-star text-muted"></i>
+        <i class="far fa-heart text-muted"></i>
         <span class="favorite-count"><%= review.favorites.count %></span>
       <% end %>
     <% end %>


### PR DESCRIPTION
# 概要
お気に入りが⭐️だと、星１評価みたいでわかりにくいのでハートに変更

# 実施した内容
- 変更箇所：お気に入りボタンの見た目・プロフィールページにあるアイコン

# 補足

# 関連issue
