### PR TITLE
fix:独自ドメインのURLが間違っていたので修正

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -118,7 +118,7 @@ Rails.application.configure do
   # ]
   # Skip DNS rebinding protection for the default health check endpoint.
   # config.host_authorization = { exclude: ->(request) { request.path == "/up" } }
-  config.hosts << "fragrance.com"      # 独自ドメイン
-  config.hosts << "www.fragrance.com"  # wwwサブドメイン
+  config.hosts << "fragrancelog.com"      # 独自ドメイン
+  config.hosts << "www.fragrancelog.com"  # wwwサブドメイン
   config.hosts << "fragrancelog.onrender.com"
 end


### PR DESCRIPTION
# 概要
config/environments/production.rbに記述したURLの修正

# 実施した内容
- ホワイトリストに追加した独自ドメインが間違っていたので正しいアドレスに修正

# 補足

# 関連issue
