### PR TITLE
update:メール送信設定のドメインを新しいものに変更

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -87,7 +87,7 @@ Rails.application.configure do
 
   # ホスト名（アプリのドメイン）
   config.action_mailer.default_url_options = {
-    host: "fragrancelog.onrender.com",
+    host: "fragrancelog.com",
     protocol: "https"
   }
   # Gmail SMTP設定


### PR DESCRIPTION
# 概要
独自ドメインが反映されたのでconfigで新しいドメインを設定

# 実施した内容
- config/environments/production.rbのホスト名設定
- config.action_mailer.default_url_options = {
host: 'your-app-domain.com'ここを本番のドメインに

# 補足

# 関連issue
#153 