### PR TITLE
Feature/#108 レビューのXシェア機能（動的OGP）

### DIFF
--- a/app/controllers/reviews_controller.rb
+++ b/app/controllers/reviews_controller.rb
@@ -2,7 +2,7 @@ class ReviewsController < ApplicationController
   skip_before_action :authenticate_user!, only: [ :index, :show ]
   before_action :set_review, only: [ :show, :edit, :update, :destroy ]
   before_action :authorize_user!, only: [ :edit, :update, :destroy ]
-  before_action :setup_meta_tags, only: [:show]
+  before_action :setup_meta_tags, only: [ :show ]
 
   def index
     @q = Review.ransack(params[:q])
@@ -101,7 +101,7 @@ class ReviewsController < ApplicationController
         protocol: request.protocol
       )
     else
-      view_context.image_url('default_fragrance.png')
+      view_context.image_url("default_fragrance.png")
     end
   end
 end

--- a/app/controllers/reviews_controller.rb
+++ b/app/controllers/reviews_controller.rb
@@ -60,4 +60,49 @@ class ReviewsController < ApplicationController
   def authorize_user!
     redirect_to reviews_path, alert: t("defaults.flash_message.not_authorized") unless @review.user == current_user
   end
+
+  def set_meta_tags
+    # レビュー本文を適切な長さに切り取り
+    description = truncate_description(@review.body)
+
+    # 香水名とブランド名を組み合わせ
+    title = "#{@review.fragrance.name} - #{@review.fragrance.brand}"
+
+    set_meta_tags(
+      title: title,
+      description: description,
+      og: {
+        title: title,
+        description: description,
+        image: fragrance_image_url(@review),
+        url: request.original_url,
+        type: "article"
+      },
+      twitter: {
+        card: "summary_large_image",
+        title: title,
+        description: description,
+        image: fragrance_image_url(@review)
+      }
+    )
+  end
+
+  def truncate_description(body)
+    # レビュー本文を適切な長さに切り取り（100文字程度）
+    body.present? ? body.truncate(100) : "香水レビューをチェック！"
+  end
+
+  def fragrance_image_url(review)
+    if review.fragrance.image.present?
+      # 画像が添付されている場合
+      Rails.env.production? ?
+        review.fragrance.image.url :
+        "#{request.protocol}#{request.host_with_port}#{review.fragrance.image.url}"
+    else
+      # デフォルト画像
+      Rails.env.production? ?
+        image_url("default_fragrance.png") :
+        "#{request.protocol}#{request.host_with_port}#{image_path("default_fragrance.png")}"
+    end
+  end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -34,7 +34,7 @@ module ApplicationHelper
   def default_meta_tags
     {
       site: "FragranceLog",
-      title: "香水レビュー・記録・管理アプリ",
+      title: "香水記録・管理・レビューアプリ",
       reverse: true,
       charset: "utf-8",
       description: "FragranceLogは、香水の記録・レビュー・診断によって香水ライフをもっと楽しくするアプリです。あなたにぴったりの香りを見つけましょう",

--- a/app/views/reviews/show.html.erb
+++ b/app/views/reviews/show.html.erb
@@ -66,6 +66,11 @@
       <div class="p-2 border rounded-md text-sm text-gray-800 bg-white">
         <%= simple_format(@review.body) %>
       </div>
+
+      <!-- Xシェアボタン -->
+      <div class="mt-4 flex justify-end">
+        <%= render 'shared/review_share_button', review: @review %>
+      </div>
     </div>
 
     <!--  コメントセクション -->

--- a/app/views/shared/_review_share_button.html.erb
+++ b/app/views/shared/_review_share_button.html.erb
@@ -1,0 +1,22 @@
+<%
+  perfume_name = "#{review.fragrance.name} - #{review.fragrance.brand}"
+  review_excerpt = truncate(review.body, length: 50)
+  share_text = <<~TEXT.strip
+    🌸 香水レビュー
+
+    「#{perfume_name}」
+
+    #{review_excerpt}
+
+    #香水レビュー #FragranceLog #香水
+  TEXT
+  share_url = request.original_url
+  twitter_url = "https://twitter.com/intent/tweet?text=#{CGI.escape(share_text)}&url=#{CGI.escape(share_url)}"
+%>
+
+<%= link_to twitter_url, target: '_blank', rel: 'noopener',
+    class: 'btn btn-primary gap-2',
+    data: { turbo: false } do %>
+  <i class="fa-brands fa-square-x-twitter"></i>
+  レビューをシェア
+<% end %>

--- a/app/views/shared/_review_share_button.html.erb
+++ b/app/views/shared/_review_share_button.html.erb
@@ -3,8 +3,7 @@
   review_excerpt = truncate(review.body, length: 50)
   share_text = <<~TEXT.strip
     🌸 香水レビュー
-
-    「#{perfume_name}」
+    #{perfume_name}
 
     #{review_excerpt}
 

--- a/app/views/shared/_x_share_button.html.erb
+++ b/app/views/shared/_x_share_button.html.erb
@@ -1,9 +1,9 @@
 <%
-  share_text = "私にぴったりの香りは「#{@result[:name]}」。#{@result[:description]} #香水診断 #FragranceLog"
+  share_text = "私にぴったりの香りは「#{@result[:name]}」 #{@result[:description]} #香水診断 #FragranceLog"
   share_url = request.original_url
   twitter_url = "https://twitter.com/intent/tweet?text=#{CGI.escape(share_text)}&url=#{CGI.escape(share_url)}"
 %>
 
-<%= link_to twitter_url, target: '_blank', rel: 'noopener', class: "x-share-btn mt-2" do %>
-  <i class="fa-brands fa-square-x-twitter"></i></> 診断結果をXでシェア
+<%= link_to twitter_url, target: '_blank', rel: 'noopener', class: "btn btn-primary gap-2 mt-2" do %>
+  <i class="fa-brands fa-square-x-twitter"></i></> 診断結果をシェア
 <% end %>


### PR DESCRIPTION
# 概要
レビュー詳細からXにシェアができる。OGP画像や文面はレビューによって変わる（動的OGP）

# 実施した内容
- レビュー用のXシェアボタンshared/_review_share_button.html.erbを作成
- レビュー詳細ページにボタンを設置
- 静的OGPの時の設定を上書きできるようreviewsコントローラーにset_meta_tagsメソッドを記述
- OGP画像は香水画像がある場合はそちらを、ない場合はデフォルトのdefault_fragrance.pngを表示するよう設定
- Localhost Open Graph DebuggerとOGP確認ツール(https://ogp.buta3.net/)で正しくOGP画像や本文が表示されるか確認

# 補足
診断結果シェアの場合は変わらず静的OGPの画像が表示できることを確認済み

# 関連issue
#108 