### PR TITLE
fix:レスポンシブ対応

### DIFF
--- a/app/views/fragrances/show.html.erb
+++ b/app/views/fragrances/show.html.erb
@@ -1,9 +1,9 @@
 <% content_for(:title, @fragrance.name) %>
 
-<section class="px-4 py-10 sm:px-6 lg:px-8">
-  <div class="max-w-4xl mx-auto bg-white p-6 rounded-xl shadow-lg">
-    <h1 class="text-2xl font-bold">
-      <span class="text-base text-gray-500 mr-2"><%= @fragrance.brand %></span>
+<section class="px-2 py-10 sm:px-6 lg:px-8">
+  <div class="max-w-4xl mx-auto bg-white p-3 sm:p-6 rounded-xl shadow-lg">
+    <h1 class="text-xl sm:text-2xl font-bold break-words">
+      <span class="text-sm sm:text-base text-gray-500 mr-2"><%= @fragrance.brand %></span>
       <%= @fragrance.name %>
     </h1>
 
@@ -17,12 +17,12 @@
       <!-- 左側 -->
       <div class="md:w-1/2">
         <% if @fragrance.image.attached? %>
-          <%= image_tag @fragrance.image.variant(resize_to_limit: [600, 400]), class: "w-full h-[250px] object-cover rounded-xl shadow-md mb-4" %>
+          <%= image_tag @fragrance.image.variant(resize_to_limit: [800, 600]), class: "w-full max-w-full h-[250px] object-cover rounded-xl shadow-md mb-4" %>
         <% else %>
-          <%= image_tag "default_fragrance.png", class: "w-full h-[250px] object-cover rounded-xl shadow-md mb-4" %>
+          <%= image_tag "default_fragrance.png", class: "w-full max-w-full h-[250px] object-cover rounded-xl shadow-md mb-4" %>
         <% end %>
 
-        <p>公開設定：<%= @fragrance.status_i18n %>
+        <p class="break-words">公開設定：<%= @fragrance.status_i18n %>
         <% if @fragrance.published? %>
           <i class="fas fa-globe" style="color: #74C0FC;" title="公開中"></i>
         <% else %>
@@ -30,12 +30,12 @@
         <% end %></p>
 
         <% if @fragrance.unpublished? %>
-          <%= link_to new_review_path(fragrance_id: @fragrance) , class: "btn btn-outline btn-sm" do %>
+          <%= link_to new_review_path(fragrance_id: @fragrance) , class: "btn btn-outline btn-sm w-full sm:w-auto" do %>
             <i class="fa-solid fa-comments"></i>
             <span>香りを紹介する</span>
           <% end %>
         <% elsif @fragrance.published? && (review = @fragrance.review) %>
-          <%= link_to review_path(review), class: "btn btn-outline btn-sm" do %>
+          <%= link_to review_path(review), class: "btn btn-outline btn-sm w-full sm:w-auto" do %>
             <i class="fa-solid fa-comments"></i>
             <span>この香水の紹介を見る</span>
           <% end %>
@@ -44,7 +44,7 @@
 
       <!-- 右側（チャート） -->
       <div class="md:w-1/2 mt-6 md:mt-0">
-        <div class="p-4 border-gray rounded bg-white shadow">
+        <div class="p-3 sm:p-4 border-gray rounded bg-white shadow overflow-hidden">
           <%= render "shared/radar_chart",
             chart_id: "fragrance_chart_#{@fragrance.id}",
             data: [
@@ -61,18 +61,18 @@
 
     <!-- ボタン -->
     <div class="mt-8 text-center space-y-4">
-      <div class="flex justify-center gap-6">
-        <%= link_to edit_fragrance_path(@fragrance), class: "btn btn-outline" do %>
+      <div class="flex flex-col sm:flex-row justify-center gap-3 sm:gap-6">
+        <%= link_to edit_fragrance_path(@fragrance), class: "btn btn-outline w-full sm:w-auto" do %>
           <i class="fa-solid fa-pen"></i>
           <span><%= t('defaults.edit') %></span>
         <% end %>
-        <%= link_to fragrance_path(@fragrance), method: :delete, data: { confirm: t('defaults.delete_confirm') }, class: "btn btn-error" do %>
+        <%= link_to fragrance_path(@fragrance), method: :delete, data: { confirm: t('defaults.delete_confirm') }, class: "btn btn-error w-full sm:w-auto" do %>
           <i class="fa-solid fa-trash"></i>
           <span><%= t('defaults.delete') %></span>
         <% end %>
       </div>
-      <div class="flex justify-center">
-        <%= link_to "マイ香水一覧に戻る", fragrances_path, class: "btn py-2 px-6 rounded-lg shadow-md" %>
+      <div class="flex justify-center mt-4">
+        <%= link_to "マイ香水一覧に戻る", fragrances_path, class: "btn py-2 px-6 rounded-lg shadow-md w-full sm:" %>
       </div>
     </div>
   </div>

--- a/app/views/reviews/show.html.erb
+++ b/app/views/reviews/show.html.erb
@@ -1,12 +1,12 @@
 <% content_for(:title, @review.fragrance.name) %>
 
-<section class="px-4 py-10 sm:px-6 lg:px-8">
-  <div class="max-w-4xl mx-auto bg-white p-6 rounded-xl shadow-lg">
+<section class="px-2 py-10 sm:px-6 lg:px-8">
+  <div class="max-w-4xl mx-auto bg-white p-3 sm:p-6 rounded-xl shadow-lg">
     <div class="flex items-start justify-between mb-4">
       <div class="flex-1">
         <%= render 'shared/favorite_button', review: @review %>
-        <h1 class="text-2xl font-bold">
-          <span class="text-base text-gray-500 mr-2"><%= @review.fragrance.brand %></span>
+        <h1 class="text-xl sm:text-2xl font-bold break-words">
+          <span class="text-sm sm:text-base text-gray-500 mr-2"><%= @review.fragrance.brand %></span>
           <%= @review.fragrance.name %>
         </h1>
 
@@ -22,13 +22,13 @@
       <!-- 左側 -->
       <div class="md:w-1/2">
         <% if @review.fragrance.image.attached? %>
-          <%= image_tag @review.fragrance.image.variant(resize_to_limit: [600, 400]), class: "w-full h-[250px] object-cover rounded-xl shadow-md mb-4" %>
+          <%= image_tag @review.fragrance.image.variant(resize_to_limit: [800, 600]), class: "w-full max-w-full h-[250px] object-cover rounded-xl shadow-md mb-4" %>
         <% else %>
-          <%= image_tag "default_fragrance.png", class: "w-full h-[250px] object-cover rounded-xl shadow-md mb-4" %>
+          <%= image_tag "default_fragrance.png", class: "w-full max-w-full h-[250px] object-cover rounded-xl shadow-md mb-4" %>
         <% end %>
 
         <!-- ユーザー名 -->
-        <div class="text-sm text-gray-600 mb-2">
+        <div class="text-sm text-gray-600 mb-2 break-words">
           <div class="avatar mr-2">
             <div class="w-6 rounded-full">
               <% if @review.user.profile_image.attached? %>
@@ -46,7 +46,7 @@
 
       <!-- 右側（チャート） -->
       <div class="md:w-1/2 mt-6 md:mt-0">
-        <div class="p-4 border-gray rounded bg-white shadow">
+        <div class="p-3 sm:p-4 border-gray rounded bg-white shadow overflow-hidden">
           <%= render "shared/radar_chart",
             chart_id: "fragrance_chart_#{@review.fragrance.id}",
             data: [
@@ -61,9 +61,9 @@
       </div>
     </div>
 
-    <div>
+    <div class="mt-4">
       <p class="font-semibold mb-1"><%= t('activerecord.attributes.review.body') %></p>
-      <div class="p-2 border rounded-md text-sm text-gray-800 bg-white">
+      <div class="p-2 border rounded-md text-sm text-gray-800 bg-white break-words">
         <%= simple_format(@review.body) %>
       </div>
 
@@ -74,7 +74,7 @@
     </div>
 
     <!--  コメントセクション -->
-    <div class="mt-8 border-t border-gray p-4">
+    <div class="mt-8 border-t border-gray p-3 sm:p-4">
       <h3 class="text-md font-semibold mb-4">コメント (<%= @review.comments.count %>)</h3>
 
       <!-- コメントフォーム -->
@@ -92,20 +92,20 @@
 
     <!-- ボタン -->
     <div class="mt-8 text-center space-y-4">
-      <div class="flex justify-center gap-6">
+      <div class="flex flex-col sm:flex-row justify-center gap-3 sm:gap-6">
         <% if current_user == @review.user %>
-          <%= link_to edit_review_path(@review), class: "btn btn-outline" do %>
+          <%= link_to edit_review_path(@review), class: "btn btn-outline w-full sm:w-auto" do %>
             <i class="fa-solid fa-pen"></i>
             <span><%= t('defaults.edit') %></span>
           <% end %>
-          <%= link_to review_path(@review), method: :delete, data: { confirm: t('defaults.unpublished_confirm') }, class: "btn btn-error" do %>
+          <%= link_to review_path(@review), method: :delete, data: { confirm: t('defaults.unpublished_confirm') }, class: "btn btn-error w-full sm:w-auto" do %>
             <i class="fa-solid fa-key"></i>
             <span>非公開にする</span>
           <% end %>
         <% end %>
       </div>
-      <div class="flex justify-center">
-        <%= link_to "みんなの香水に戻る", reviews_path, class: "btn py-2 px-6 rounded-lg shadow-md" %>
+      <div class="flex justify-center mt-4">
+        <%= link_to "みんなの香水に戻る", reviews_path, class: "btn py-2 px-6 rounded-lg shadow-md w-full sm:w-auto" %>
       </div>
     </div>
   </div>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -62,11 +62,7 @@
       </div>
     <% else %>
       <!-- 未ログイン時の表示 -->
-      <%= link_to new_user_registration_path, class: "btn btn-outline btn-sm" do %>
-        <i class="fa-solid fa-user-plus"></i>
-        <%= t('header.sign_up') %>
-      <% end %>
-      <%= link_to new_user_session_path, class: "btn btn-primary btn-sm" do %>
+      <%= link_to new_user_session_path, class: "btn btn-outline btn-sm" do %>
         <i class="fa-solid fa-right-to-bracket"></i>
         <%= t('header.login') %>
       <% end %>


### PR DESCRIPTION
# 概要
スマホで見たときに見た目がおかしい部分を修正

# 実施した内容
- ヘッダーから新規登録ボタンを削除(ログイン画面から飛んでもらう形に)
- マイ香水・みんなの香水詳細画面の横幅を狭く

# 補足

# 関連issue
#163 
