### PR TITLE
Feature/#97 香水検索のオートコンプリート

### DIFF
--- a/app/controllers/reviews_controller.rb
+++ b/app/controllers/reviews_controller.rb
@@ -49,7 +49,7 @@ class ReviewsController < ApplicationController
   end
 
   def autocomplete
-    term = params[:term]
+    term = params[:term] || params[:q]  # パラメータ名を両方対応
 
     if term.blank? || term.length < 2
       render json: []
@@ -64,14 +64,32 @@ class ReviewsController < ApplicationController
                           .distinct
                           .limit(10)
 
-    results = fragrances.map do |fragrance|
-      {
-        id: fragrance.id,
-        perfume_name: fragrance.name,
-        brand_name: fragrance.brand,
-        value: "#{fragrance.brand} #{fragrance.name}"
-      }
+    # 🎯 ブランド名と香水名を個別に抽出
+    brands = []
+    names = []
+
+    fragrances.each do |fragrance|
+      # ブランド名が検索語に一致する場合
+      if fragrance.brand.downcase.include?(term.downcase)
+        brands << {
+          value: fragrance.brand,
+          type: "brand",
+          label: "#{fragrance.brand}（ブランド）"
+        }
+      end
+
+      # 香水名が検索語に一致する場合
+      if fragrance.name.downcase.include?(term.downcase)
+        names << {
+          value: fragrance.name,
+          type: "name",
+          label: "#{fragrance.name}（香水名）"
+        }
+      end
     end
+
+    # 🎯 重複を除去して結合
+    results = (brands + names).uniq { |item| item[:value] }[0, 8]
 
     render json: results
   end

--- a/app/controllers/reviews_controller.rb
+++ b/app/controllers/reviews_controller.rb
@@ -56,20 +56,20 @@ class ReviewsController < ApplicationController
       return
     end
 
-    fragrances = Fragrance.published
+    fragrances = Fragrance.where(status: :published)
                           .where(
                             "name ILIKE ? OR brand ILIKE ?",
                             "%#{term}%", "%#{term}%"
                           )
-                          .limit(10)
                           .distinct
+                          .limit(10)
 
     results = fragrances.map do |fragrance|
       {
         id: fragrance.id,
         perfume_name: fragrance.name,
-        brand_name: fragrance.brand.name,
-        value: "#{fragrance.brand.name} #{fragrance.name}"
+        brand_name: fragrance.brand,
+        value: "#{fragrance.brand} #{fragrance.name}"
       }
     end
 

--- a/app/javascript/controllers/auto_complete_controller.js
+++ b/app/javascript/controllers/auto_complete_controller.js
@@ -70,8 +70,7 @@ export default class extends Controller {
         )
 
         element.innerHTML = `
-          <div class="font-semibold text-gray-800">${this.escapeHtml(item.brand_name)}</div>
-          <div class="text-sm text-gray-600">${this.escapeHtml(item.perfume_name)}</div>
+          <div class="font-semibold text-gray-800">${this.escapeHtml(item.value)}</div>
         `
 
         element.dataset.index = index

--- a/app/javascript/controllers/auto_complete_controller.js
+++ b/app/javascript/controllers/auto_complete_controller.js
@@ -3,20 +3,26 @@ import { Controller } from "@hotwired/stimulus"
 // Connects to data-controller="auto-complete"
 export default class extends Controller {
   static targets = ["input", "results"]
+  static values = { url: String, delay: { type: Number, default: 300 } }
 
   connect() {
     console.log("AutoCompleteが接続されました")
     this.resultsTarget.hidden = true
+    this.timeout = null // デバウンス用のタイマー
 
-    this.inputTarget.addEventListener("input", this.search.bind(this))
-    this.inputTarget.addEventListener("focus", this.search.bind(this))
+    this.inputTarget.addEventListener("input", this.handleInput.bind(this))
+    this.inputTarget.addEventListener("focus", this.handleInput.bind(this))
     document.addEventListener("click", this.hideResults.bind(this))
   }
 
-  hideResults(event) {
-    if (!this.element.contains(event.target)) {
-      this.resultsTarget.hidden = true
-    }
+  handleInput() {
+    // 前回のタイマーをクリア
+    clearTimeout(this.timeout)
+
+    // 新しいタイマーを設定
+    this.timeout = setTimeout(() => {
+      this.search()
+    }, this.delayValue)
   }
 
   async search() {
@@ -27,32 +33,52 @@ export default class extends Controller {
     }
 
     try {
-      const response = await fetch(`/reviews/autocomplete?term=${encodeURIComponent(query)}`)
+      const url = this.urlValue || `/reviews/autocomplete?term=${encodeURIComponent(query)}`
+      const response = await fetch(url)
       const data = await response.json()
 
-      this.resultsTarget.innerHTML = ""
-
-      if (data.length > 0) {
-        this.resultsTarget.hidden = false
-
-        data.forEach(item => {
-          const element = document.createElement("div")
-          element.classList.add("p-2", "hover:bg-gray-100", "cursor-pointer")
-
-          element.dataset.id = item.id
-          element.addEventListener("click", () => this.selectResult(item))
-          this.resultsTarget.appendChild(element)
-        })
-      } else {
-        this.resultsTarget.hidden = true
-      }
+      this.displayResults(data)
     } catch (error) {
       console.error("オートコンプリートエラー:", error)
+      this.resultsTarget.hidden = true
+    }
+  }
+
+  displayResults(data) {
+    this.resultsTarget.innerHTML = ""
+
+    if (data.length > 0) {
+      this.resultsTarget.hidden = false
+
+      data.forEach(item => {
+        const element = document.createElement("div")
+        element.classList.add("autocomplete-item", "p-2", "hover:bg-gray-100", "cursor-pointer", "border-b")
+
+        // 香水の場合はブランド名と商品名を分けて表示
+        element.innerHTML = `
+          <div class="font-medium">${item.brand_name}</div>
+          <div class="text-sm text-gray-600">${item.perfume_name}</div>
+        `
+
+        element.dataset.id = item.id
+        element.addEventListener("click", () => this.selectResult(item))
+        this.resultsTarget.appendChild(element)
+      })
+    } else {
+      // 検索結果がない場合
+      const noResultElement = document.createElement("div")
+      noResultElement.classList.add("p-2", "text-gray-500", "text-center")
+      noResultElement.textContent = "該当する香水が見つかりませんでした"
+      this.resultsTarget.appendChild(noResultElement)
+      this.resultsTarget.hidden = false
     }
   }
 
   selectResult(item) {
-    this.inputTarget.value = item.value
+    // ブランド名と香水名を組み合わせて表示
+    this.inputTarget.value = `${item.brand_name} ${item.perfume_name}`
     this.resultsTarget.hidden = true
+
+    this.inputTarget.focus()
   }
 }

--- a/app/javascript/controllers/auto_complete_controller.js
+++ b/app/javascript/controllers/auto_complete_controller.js
@@ -59,7 +59,8 @@ export default class extends Controller {
         const element = document.createElement("div")
         element.classList.add(
           "autocomplete-item",
-          "p-3",
+          "px-4",
+          "py-2",
           "border-b",
           "border-gray-200",
           "cursor-pointer",
@@ -102,5 +103,61 @@ export default class extends Controller {
       this.resultsTarget.classList.add('hidden')
       this.selectedIndex = -1
     }
+  }
+
+  handleKeydown(event) {
+    const items = this.resultsTarget.querySelectorAll('.autocomplete-item')
+
+    if (items.length === 0) return
+
+    switch (event.key) {
+      case 'ArrowDown':
+        event.preventDefault()
+        this.selectedIndex = Math.min(this.selectedIndex + 1, items.length - 1)
+        this.updateSelection()
+        break
+
+      case 'ArrowUp':
+        event.preventDefault()
+        this.selectedIndex = Math.max(this.selectedIndex - 1, -1)
+        this.updateSelection()
+        break
+
+      case 'Enter':
+        event.preventDefault()
+        if (this.selectedIndex >= 0 && items[this.selectedIndex]) {
+          const selectedItem = items[this.selectedIndex]
+          const index = parseInt(selectedItem.dataset.index)
+
+          const brand = selectedItem.querySelector('div:first-child').textContent
+          const perfume = selectedItem.querySelector('div:last-child').textContent
+          this.inputTarget.value = `${brand} ${perfume}`
+          this.resultsTarget.classList.add('hidden')
+        }
+        break
+
+      case 'Escape':
+        this.resultsTarget.classList.add('hidden')
+        this.selectedIndex = -1
+        break
+    }
+  }
+
+  updateSelection() {
+    const items = this.resultsTarget.querySelectorAll('.autocomplete-item')
+
+    items.forEach((item, index) => {
+      if (index === this.selectedIndex) {
+        item.classList.add('bg-gray-100')
+      } else {
+        item.classList.remove('bg-gray-100')
+      }
+    })
+  }
+
+  escapeHtml(text) {
+    const div = document.createElement('div')
+    div.textContent = text
+    return div.innerHTML
   }
 }

--- a/app/javascript/controllers/auto_complete_controller.js
+++ b/app/javascript/controllers/auto_complete_controller.js
@@ -1,0 +1,58 @@
+import { Controller } from "@hotwired/stimulus"
+
+// Connects to data-controller="auto-complete"
+export default class extends Controller {
+  static targets = ["input", "results"]
+
+  connect() {
+    console.log("AutoCompleteが接続されました")
+    this.resultsTarget.hidden = true
+
+    this.inputTarget.addEventListener("input", this.search.bind(this))
+    this.inputTarget.addEventListener("focus", this.search.bind(this))
+    document.addEventListener("click", this.hideResults.bind(this))
+  }
+
+  hideResults(event) {
+    if (!this.element.contains(event.target)) {
+      this.resultsTarget.hidden = true
+    }
+  }
+
+  async search() {
+    const query = this.inputTarget.value.trim()
+    if (query.length < 2) {
+      this.resultsTarget.hidden = true
+      return
+    }
+
+    try {
+      const response = await fetch(`/reviews/autocomplete?term=${encodeURIComponent(query)}`)
+      const data = await response.json()
+
+      this.resultsTarget.innerHTML = ""
+
+      if (data.length > 0) {
+        this.resultsTarget.hidden = false
+
+        data.forEach(item => {
+          const element = document.createElement("div")
+          element.classList.add("p-2", "hover:bg-gray-100", "cursor-pointer")
+
+          element.dataset.id = item.id
+          element.addEventListener("click", () => this.selectResult(item))
+          this.resultsTarget.appendChild(element)
+        })
+      } else {
+        this.resultsTarget.hidden = true
+      }
+    } catch (error) {
+      console.error("オートコンプリートエラー:", error)
+    }
+  }
+
+  selectResult(item) {
+    this.inputTarget.value = item.value
+    this.resultsTarget.hidden = true
+  }
+}

--- a/app/javascript/controllers/index.js
+++ b/app/javascript/controllers/index.js
@@ -4,5 +4,8 @@
 
 import { application } from "./application"
 
+import AutoCompleteController from "./auto_complete_controller"
+application.register("auto-complete", AutoCompleteController)
+
 import HelloController from "./hello_controller"
 application.register("hello", HelloController)

--- a/app/views/reviews/_search_form.html.erb
+++ b/app/views/reviews/_search_form.html.erb
@@ -4,23 +4,28 @@
     <%= search_form_for q, url: reviews_path, method: :get, class: "mb-6", local: true do |f| %>
       <div class="space-y-4">
         <!-- 香水名・ブランド名検索（上段） -->
-        <div class="form-control"
-              data-controller="auto-complete"
-              data-auto-complete-url-value="<%= autocomplete_reviews_path %>">
+        <div class="form-control">
           <%= f.label :fragrance_name_or_fragrance_brand_cont, "香水名・ブランド名", class: "label font-semibold text-gray-700" %>
-          <div class="flex gap-2">
-            <%= f.search_field :fragrance_name_or_fragrance_brand_cont,
-              class: "input input-bordered flex-1",
-              placeholder: "例：シャネル",
-              data: {
-                auto_complete_target: "input",
-                action: "input->auto-complete#handleInput focus->auto-complete#handleInput keydown->auto-complete#handleKeydown"
-              } %>
 
-            <!-- オートコンプリート結果表示 -->
-            <div data-auto-complete-target="results"
-                  class="absolute top-full left-0 right-0 bg-white border border-gray-300 rounded-lg shadow-lg z-50 max-h-60 overflow-y-auto hidden"
-                  style="margin-top: 1px;">
+          <div class="flex gap-2">
+            <!-- オートコンプリート全体のコンテナ -->
+            <div class="flex-1 relative"
+                  data-controller="auto-complete"
+                  data-auto-complete-url-value="<%= autocomplete_reviews_path %>">
+
+              <!-- 入力フィールド -->
+              <%= f.search_field :fragrance_name_or_fragrance_brand_cont,
+                class: "input input-bordered w-full",
+                placeholder: "例：シャネル",
+                data: {
+                  auto_complete_target: "input",
+                  action: "input->auto-complete#handleInput focus->auto-complete#handleInput keydown->auto-complete#handleKeydown"
+                } %>
+
+              <!-- オートコンプリート結果表示（入力フィールドの真下） -->
+              <div data-auto-complete-target="results"
+                    class="bg-white border border-gray-300 rounded-lg shadow-lg z-50 max-h-60 overflow-y-auto hidden mt-1">
+              </div>
             </div>
 
             <!-- 検索ボタン -->

--- a/app/views/reviews/_search_form.html.erb
+++ b/app/views/reviews/_search_form.html.erb
@@ -4,12 +4,24 @@
     <%= search_form_for q, url: reviews_path, method: :get, class: "mb-6", local: true do |f| %>
       <div class="space-y-4">
         <!-- 香水名・ブランド名検索（上段） -->
-        <div class="form-control">
+        <div class="form-control"
+              data-controller="auto-complete"
+              data-auto-complete-url-value="<%= autocomplete_reviews_path %>">
           <%= f.label :fragrance_name_or_fragrance_brand_cont, "香水名・ブランド名", class: "label font-semibold text-gray-700" %>
           <div class="flex gap-2">
             <%= f.search_field :fragrance_name_or_fragrance_brand_cont,
               class: "input input-bordered flex-1",
-              placeholder: "例：シャネル" %>
+              placeholder: "例：シャネル",
+              data: {
+                auto_complete_target: "input",
+                action: "input->auto-complete#handleInput focus->auto-complete#handleInput keydown->auto-complete#handleKeydown"
+              } %>
+
+            <!-- オートコンプリート結果表示 -->
+            <div data-auto-complete-target="results"
+                  class="absolute top-full left-0 right-0 bg-white border border-gray-300 rounded-lg shadow-lg z-50 max-h-60 overflow-y-auto hidden"
+                  style="margin-top: 1px;">
+            </div>
 
             <!-- 検索ボタン -->
             <button type="submit" class="btn btn-primary">
@@ -27,7 +39,7 @@
             <%= f.collection_select :fragrance_tags_id_eq,
               Tag.all, :id, :name,
                 { prompt: "カテゴリを選択" },
-                { class: "select select-bordered w-full" } %>
+                { class: "select select-bordered w-full bg-white" } %>
           </div>
         </div>
       </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -11,6 +11,9 @@ Rails.application.routes.draw do
   resources :reviews do
     resource :favorite, only: %i[create destroy]
     resources :comments, only: %i[create destroy edit update], shallow: true
+    collection do
+      get :autocomplete
+    end
   end
   resource :diagnosis, only: %i[new create ] do
     get :result


### PR DESCRIPTION
# 概要
ブランド名or香水名での検索時にキーワードに候補を表示する(２文字以上入力した時)

# 実施した内容
- docker compose exec web rails g stimulus auto_completeコマンドでStimulusコントローラーを作成する
- auto_complete_controller.jsにJavaScriptでオートコンプリートの処理を記述する
- reviews_controller.rbにautocompeteメソッドを作成する
- routes.rbでautocompeteメソッドのルーティング設定をネストする
- _search_form.html.erbでオートコンプリートの候補を表示（香水名とブランド名は分けて表示）

# 補足
ひらがなとカタカナが区別されている状態

# 関連issue
#97 