### PR TITLE
Feature/#107 香り診断のステップフォーム化

### DIFF
--- a/app/javascript/controllers/index.js
+++ b/app/javascript/controllers/index.js
@@ -9,3 +9,6 @@ application.register("auto-complete", AutoCompleteController)
 
 import HelloController from "./hello_controller"
 application.register("hello", HelloController)
+
+import StepFormController from "./step_form_controller"
+application.register("step-form", StepFormController)

--- a/app/javascript/controllers/step_form_controller.js
+++ b/app/javascript/controllers/step_form_controller.js
@@ -1,7 +1,7 @@
 import { Controller } from "@hotwired/stimulus"
 
 export default class extends Controller {
-  static targets = ["step"]
+  static targets = ["step", "nextButton"]
   static values = { currentStep: Number, totalSteps: Number }
 
   connect() {
@@ -11,7 +11,7 @@ export default class extends Controller {
   }
 
   next() {
-    if (this.currentStepValue < this.totalStepsValue) {
+    if (this.canProceed() && this.currentStepValue < this.totalStepsValue) {
       this.currentStepValue++
       this.showCurrentStep()
     }
@@ -24,6 +24,11 @@ export default class extends Controller {
     }
   }
 
+  // 回答状況をチェックするメソッド（ラジオボタンの変更時に呼び出される）
+  checkAnswer() {
+    this.updateNextButtonState()
+  }
+
   showCurrentStep() {
     this.stepTargets.forEach((step, index) => {
       if (index === this.currentStepValue - 1) {
@@ -33,12 +38,38 @@ export default class extends Controller {
       }
     })
     this.updateProgressIndicator()
+    this.updateNextButtonState()
   }
 
   updateProgressIndicator() {
     const indicator = this.element.querySelector('.progress-indicator')
     if (indicator) {
       indicator.textContent = `${this.currentStepValue}/${this.totalStepsValue}`
+    }
+  }
+
+  // 現在のステップで回答が選択されているかチェック
+  canProceed() {
+    const currentStepElement = this.stepTargets[this.currentStepValue - 1]
+    const radioButtons = currentStepElement.querySelectorAll('input[type="radio"]')
+    return Array.from(radioButtons).some(radio => radio.checked)
+  }
+
+  // 進むボタンの有効/無効を切り替え
+  updateNextButtonState() {
+    const currentStepElement = this.stepTargets[this.currentStepValue - 1]
+    const nextButton = currentStepElement.querySelector('[data-step-form-target="nextButton"]')
+
+    if (nextButton) {
+      if (this.canProceed()) {
+        nextButton.disabled = false
+        nextButton.classList.remove('btn-disabled', 'opacity-70', 'cursor-not-allowed')
+        nextButton.classList.add('btn-primary')
+      } else {
+        nextButton.disabled = true
+        nextButton.classList.add('btn-disabled', 'opacity-70', 'cursor-not-allowed')
+        nextButton.classList.remove('btn-primary')
+      }
     }
   }
 }

--- a/app/javascript/controllers/step_form_controller.js
+++ b/app/javascript/controllers/step_form_controller.js
@@ -38,13 +38,24 @@ export default class extends Controller {
       }
     })
     this.updateProgressIndicator()
+    this.updateProgressBar()
     this.updateNextButtonState()
   }
 
+  // プログレスインジゲーターの数値更新
   updateProgressIndicator() {
     const indicator = this.element.querySelector('.progress-indicator')
     if (indicator) {
       indicator.textContent = `${this.currentStepValue}/${this.totalStepsValue}`
+    }
+  }
+
+  // プログレスバーの更新
+  updateProgressBar() {
+    const progressBar = this.element.querySelector('.progress-bar')
+    if (progressBar) {
+      const percentage = (this.currentStepValue / this.totalStepsValue) * 100
+      progressBar.style.width = `${percentage}%`
     }
   }
 

--- a/app/javascript/controllers/step_form_controller.js
+++ b/app/javascript/controllers/step_form_controller.js
@@ -1,0 +1,44 @@
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+  static targets = ["step"]
+  static values = { currentStep: Number, totalSteps: Number }
+
+  connect() {
+    this.currentStepValue = 1
+    this.totalStepsValue = this.stepTargets.length
+    this.showCurrentStep()
+  }
+
+  next() {
+    if (this.currentStepValue < this.totalStepsValue) {
+      this.currentStepValue++
+      this.showCurrentStep()
+    }
+  }
+
+  previous() {
+    if (this.currentStepValue > 1) {
+      this.currentStepValue--
+      this.showCurrentStep()
+    }
+  }
+
+  showCurrentStep() {
+    this.stepTargets.forEach((step, index) => {
+      if (index === this.currentStepValue - 1) {
+        step.style.display = "block"
+      } else {
+        step.style.display = "none"
+      }
+    })
+    this.updateProgressIndicator()
+  }
+
+  updateProgressIndicator() {
+    const indicator = this.element.querySelector('.progress-indicator')
+    if (indicator) {
+      indicator.textContent = `${this.currentStepValue}/${this.totalStepsValue}`
+    }
+  }
+}

--- a/app/views/diagnoses/new.html.erb
+++ b/app/views/diagnoses/new.html.erb
@@ -8,8 +8,17 @@
       data-controller="step-form">
 
   <!-- プログレスインジケーター -->
-  <div class="mb-6 text-center">
-    <span class="progress-indicator text-lg font-semibold text-indigo-600"></span>
+  <div class="mb-8">
+    <!-- 数値表示 -->
+    <div class="text-center mb-3">
+      <span class="progress-indicator text-lg font-semibold text-primary"></span>
+    </div>
+
+    <!-- プログレスバー -->
+    <div class="w-full bg-gray-200 rounded-full h-3">
+      <div class="progress-bar bg-primary h-3 rounded-full transition-all duration-300 ease-in-out" 
+            style="width: 0%"></div>
+    </div>
   </div>
 
   <%= form_with url: diagnosis_path, method: :post do %>

--- a/app/views/diagnoses/new.html.erb
+++ b/app/views/diagnoses/new.html.erb
@@ -1,23 +1,61 @@
 <% content_for(:title, t('.title')) %>
-<h1 class="text-3xl font-bold mb-6 text-center "><i class="fa-solid fa-magnifying-glass-plus"></i> <%= t('.title') %></h1>
 
-<%= form_with url: diagnosis_path, method: :post, class: "max-w-xl mx-auto bg-white p-6 rounded-xl shadow-lg" do %>
+<h1 class="text-3xl font-bold mb-6 text-center">
+  <i class="fa-solid fa-magnifying-glass-plus"></i> <%= t('.title') %>
+</h1>
 
-  <% @questions.each do |key, data| %>
-    <fieldset class="mb-6">
-      <legend class="mb-2 text-lg font-semibold text-gray-700"><%= data[:question] %></legend>
-      <div class="space-y-2">
-        <% data[:options].each do |option_key, option_data| %>
-          <label class="flex items-center space-x-3 cursor-pointer hover:bg-gray-100 rounded px-3 py-2">
-            <%= radio_button_tag "answers[#{key}]", option_key, (@selected_answers && @selected_answers[key.to_s] == option_key), class: "form-radio text-indigo-600" %>
-            <span class="text-gray-800"><%= option_data[:text] %></span>
-          </label>
-        <% end %>
-      </div>
-    </fieldset>
-  <% end %>
+<div class="max-w-xl mx-auto bg-white p-6 rounded-xl shadow-lg"
+    data-controller="step-form">
 
-  <div class="flex justify-between items-center">
-    <%= submit_tag t('.submit'), class: "btn btn-primary" %>
+  <!-- プログレスインジケーター -->
+  <div class="mb-6 text-center">
+    <span class="progress-indicator text-lg font-semibold text-indigo-600"></span>
   </div>
-<% end %>
+
+  <%= form_with url: diagnosis_path, method: :post do %>
+
+    <% @questions.each_with_index do |(key, data), index| %>
+      <div class="step" data-step-form-target="step" style="display: none;">
+        <fieldset class="mb-6">
+          <legend class="mb-4 text-xl font-semibold text-gray-700 text-center">
+            <%= data[:question] %>
+          </legend>
+          <div class="space-y-3">
+            <% data[:options].each do |option_key, option_data| %>
+              <label class="flex items-center space-x-3 cursor-pointer hover:bg-gray-100 rounded px-3 py-2">
+                <%= radio_button_tag "answers[#{key}]", option_key,
+                    (@selected_answers && @selected_answers[key.to_s] == option_key), 
+                    class: "form-radio text-indigo-600" %>
+                <span class="text-gray-800"><%= option_data[:text] %></span>
+              </label>
+            <% end %>
+          </div>
+        </fieldset>
+
+        <!-- ナビゲーションボタン -->
+        <div class="flex justify-between items-center mt-6">
+          <% if index > 0 %>
+            <button type="button"
+                    data-action="click->step-form#previous"
+                    class="btn btn-secondary">
+              前へ
+            </button>
+          <% else %>
+            <div></div>
+          <% end %>
+
+          <% if index < @questions.length - 1 %>
+            <button type="button"
+                    data-action="click->step-form#next"
+                    class="btn btn-primary">
+              次へ
+            </button>
+          <% else %>
+            <%= submit_tag t('.submit'), class: "btn btn-primary" %>
+          <% end %>
+        </div>
+      </div>
+    <% end %>
+
+  <% end %>
+</div>

--- a/app/views/diagnoses/new.html.erb
+++ b/app/views/diagnoses/new.html.erb
@@ -5,7 +5,7 @@
 </h1>
 
 <div class="max-w-xl mx-auto bg-white p-6 rounded-xl shadow-lg"
-    data-controller="step-form">
+      data-controller="step-form">
 
   <!-- プログレスインジケーター -->
   <div class="mb-6 text-center">
@@ -25,7 +25,8 @@
               <label class="flex items-center space-x-3 cursor-pointer hover:bg-gray-100 rounded px-3 py-2">
                 <%= radio_button_tag "answers[#{key}]", option_key,
                     (@selected_answers && @selected_answers[key.to_s] == option_key), 
-                    class: "form-radio text-indigo-600" %>
+                    class: "form-radio text-indigo-600",
+                    data: { action: "change->step-form#checkAnswer" } %>
                 <span class="text-gray-800"><%= option_data[:text] %></span>
               </label>
             <% end %>
@@ -37,7 +38,7 @@
           <% if index > 0 %>
             <button type="button"
                     data-action="click->step-form#previous"
-                    class="btn btn-secondary">
+                    class="btn btn-outline">
               前へ
             </button>
           <% else %>
@@ -47,11 +48,16 @@
           <% if index < @questions.length - 1 %>
             <button type="button"
                     data-action="click->step-form#next"
-                    class="btn btn-primary">
+                    data-step-form-target="nextButton"
+                    class="btn btn-disabled opacity-70 cursor-not-allowed"
+                    disabled>
               次へ
             </button>
           <% else %>
-            <%= submit_tag t('.submit'), class: "btn btn-primary" %>
+            <%= submit_tag t('.submit'),
+                class: "btn btn-disabled opacity-70 cursor-not-allowed",
+                data: { step_form_target: "nextButton" },
+                disabled: true %>
           <% end %>
         </div>
       </div>


### PR DESCRIPTION
# 概要
香水診断の４つの設問をステップ式にする

# 実施した内容
- docker compose exec web rails g stimulus step_formコマンドでStimulusコントローラーを作成する
- step_form_controller.jsにJavaScriptで設問の表示・非表示を切り替える
- app/views/diagnoses/new.html.erbを編集し、次へボタンと戻るボタンを設置、回答状況をプログレスバーと数値で表示
- ラジオボタンが選択されるまでは次へボタンは押せないように

# 補足

# 関連issue
#107 