### PR TITLE
Fix/#182 香水名・ブランド名を詳細へのリンクに

### DIFF
--- a/app/views/fragrances/_fragrance.html.erb
+++ b/app/views/fragrances/_fragrance.html.erb
@@ -1,7 +1,7 @@
 <div class="bg-white backdrop-blur-m p-4 rounded-xl shadow-lg flex flex-col relative">
   <!-- ボトル画像 -->
   <div class="h-60 flex items-center justify-center rounded-md overflow-hidden">
-    <%= link_to fragrance_path(fragrance), data: { action: "click->loading#show" } do %>
+    <%= link_to fragrance_path(fragrance) do %>
       <div class="object-cover w-full h-[200px] cursor-pointer transition hover:opacity-80">
         <% if fragrance.image.attached? %>
           <%= image_tag fragrance.image.variant(resize_to_limit: [600, 400]), class: "w-full h-full object-cover rounded-xl shadow" %>
@@ -14,8 +14,10 @@
 
   <!-- ブランド名・香水名 -->
   <div class="flex flex-grow flex-col px-3 mt-4">
-    <p class="text-sm text-gray-500 font-semibold"><%= fragrance.brand %></p>
-    <p class="text-xl font-bold"><%= fragrance.name %></p>
+    <%= link_to fragrance_path(fragrance) do %>
+      <p class="text-sm text-gray-500 font-semibold"><%= fragrance.brand %></p>
+      <p class="text-xl font-bold"><%= fragrance.name %></p>
+    <% end %>
 
     <!-- タグ -->
     <div class="mt-2 mb-3">

--- a/app/views/profiles/_favorite_review.html.erb
+++ b/app/views/profiles/_favorite_review.html.erb
@@ -8,7 +8,7 @@
   <% fragrance = review.fragrance %>
   <!-- ボトル画像 -->
   <div class="h-48 flex items-center justify-center rounded-md overflow-hidden">
-    <%= link_to review_path(review), data: { action: "click->loading#show" } do %>
+    <%= link_to review_path(review) do %>
       <div class="object-cover w-full h-[160px] cursor-pointer transition hover:opacity-80">
         <% if fragrance.image.attached? %>
           <%= image_tag fragrance.image.variant(resize_to_limit: [400, 300]), class: "w-full h-full object-cover rounded-xl shadow" %>

--- a/app/views/reviews/_review.html.erb
+++ b/app/views/reviews/_review.html.erb
@@ -2,7 +2,7 @@
   <% fragrance = review.fragrance %>
   <!-- ボトル画像 -->
   <div class="h-60 flex items-center justify-center rounded-md overflow-hidden">
-    <%= link_to review_path(review), data: { action: "click->loading#show" } do %>
+    <%= link_to review_path(review) do %>
       <div class="object-cover w-full h-[200px] cursor-pointer transition hover:opacity-80">
         <% if fragrance.image.attached? %>
           <%= image_tag fragrance.image.variant(resize_to_limit: [600, 400]), class: "w-full h-full object-cover rounded-xl shadow" %>
@@ -15,8 +15,10 @@
 
   <!-- ブランド名・香水名 -->
   <div class="flex flex-grow flex-col px-3 mt-4">
-    <p class="text-sm text-gray-500 font-semibold"><%= fragrance.brand %></p>
-    <p class="text-xl font-bold"><%= fragrance.name %></p>
+    <%= link_to review_path(review) do %>
+      <p class="text-sm text-gray-500 font-semibold"><%= fragrance.brand %></p>
+      <p class="text-xl font-bold"><%= fragrance.name %></p>
+    <% end %>
 
     <!-- タグ -->
     <div class="mt-2 mb-3">


### PR DESCRIPTION
# 概要
一覧→詳細へのリンクが画像のみだったため、ブランド名・香水名からも遷移できるよう変更

# 実施した内容
- fragrance一覧のカード部分でブランド名・香水名に詳細へのリンク追加
- 同じくレビュー一覧→詳細も対応

# 補足
カード全体をリンクにするとタグ・お気に入りボタンとぶつかるので一旦見送り

# 関連issue
#182 