### PR TITLE
プロフ画像未設定時はマイページにデフォルトアイコンを表示

### DIFF
--- a/app/views/profiles/show.html.erb
+++ b/app/views/profiles/show.html.erb
@@ -15,7 +15,9 @@
             <% if @user.profile_image.attached? %>
               <%= image_tag @user.profile_image, alt: "プロフィール画像" %>
             <% else %>
-              <%= image_tag "default_profile_image.png", alt: "デフォルトプロフィール画像" %>
+              <div class="bg-neutral text-neutral-content rounded-full w-48 h-48 flex items-center justify-center">
+                <i class="fa-solid fa-user text-6xl"></i>
+              </div>
             <% end %>
           </div>
         </div>


### PR DESCRIPTION
# 概要
プロフ画像未設定時の表示がマイページとレビュー一覧で異なるので揃えた

# 実施した内容
- マイページでもFont Awesomeアイコンを表示

# 補足

# 関連issue
#189 