### PR TITLE
dependabotの頻度変更

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,10 +3,10 @@ updates:
 - package-ecosystem: bundler
   directory: "/"
   schedule:
-    interval: daily
-  open-pull-requests-limit: 10
+    interval: monthly
+  open-pull-requests-limit: 5
 - package-ecosystem: github-actions
   directory: "/"
   schedule:
-    interval: daily
-  open-pull-requests-limit: 10
+    interval: monthly
+  open-pull-requests-limit: 5


### PR DESCRIPTION
# 概要
dependabotからの通知が毎日くるため頻度を下げた
一度にopen状態になるプルリクも５件に制限

# 実施した内容
- [ ] 

# 補足

# 関連issue
