### PR TITLE
favoriteコントローラのcreateとdestroyアクションにエラーハンドリング

### DIFF
--- a/app/controllers/favorites_controller.rb
+++ b/app/controllers/favorites_controller.rb
@@ -8,17 +8,46 @@ class FavoritesController < ApplicationController
         format.turbo_stream
         format.html { redirect_to review_path(@review) }
       end
+    else
+      respond_to do |format|
+        format.turbo_stream do
+          render turbo_stream: turbo_stream.replace(
+            "favorite_button_#{@review.id}",
+            partial: "shared/favorite_button",
+            locals: { review: @review }
+          ), status: :unprocessable_entity
+        end
+        format.html do
+          redirect_to review_path(@review),
+                      alert: "お気に入りに追加できませんでした。"
+        end
+      end
     end
   end
 
   def destroy
     @review = Review.find(params[:review_id])
     @favorite = current_user.favorites.find_by(review: @review)
-    @favorite&.destroy
 
-    respond_to do |format|
-      format.turbo_stream
-      format.html { redirect_to review_path(@review) }
+    if @favorite&.destroy
+      respond_to do |format|
+        format.turbo_stream
+        format.html { redirect_to review_path(@review) }
+      end
+    else
+      respond_to do |format|
+        format.turbo_stream do
+          render turbo_stream: turbo_stream.replace(
+            "favorite_button_#{@review.id}",
+            partial: "shared/favorite_button",
+            locals: { review: @review }
+          ), status: :unprocessable_entity
+        end
+        format.html do
+          redirect_to review_path(@review),
+                      alert: "お気に入りの削除に失敗しました。"
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
# 概要
Favoritesコントローラーにエラーハンドリングを追加

# 実施した内容
createアクション
  - 成功時: 従来通りTurbo Streamまたはリダイレクト
  - 失敗時:
    - Turbo Stream: ボタンを元の状態に戻す
    - HTML: エラーメッセージ付きでリダイレクト

 destroyアクション
  - 成功時: 従来通りTurbo Streamまたはリダイレクト
  - 失敗時:
    - @favoriteがnilまたはdestroyが失敗した場合
    - Turbo Stream: ボタンを元の状態に戻す
    - HTML: エラーメッセージ付きでリダイレクト

# 補足

# 関連issue
